### PR TITLE
My modifications... I like them.

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -79,6 +79,7 @@ void modesInitConfig(void) {
     Modes.interactive_display_ttl = MODES_INTERACTIVE_DISPLAY_TTL;
     Modes.fUserLat                = MODES_USER_LATITUDE_DFLT;
     Modes.fUserLon                = MODES_USER_LONGITUDE_DFLT;
+    Modes.interactive_refresh_time= MODES_INTERACTIVE_REFRESH_TIME;
     Modes.trail_buffsz=MODES_TRAIL_BUFFSZ;
     Modes.trail_mask=MODES_TRAIL_BUFFSZ-1;
     Modes.rcv_hgt=0;
@@ -476,6 +477,7 @@ void showHelp(void) {
 "--interactive-rows <num> Max number of rows in interactive mode (default: 15)\n"
 "--interactive-ttl <sec>  Remove from list if idle for <sec> (default: 60)\n"
 "--interactive-rtl1090    Display flight table in RTL1090 format\n"
+"--interactive-refresh <ms> Refresh screen every ms miliseconds (default 250)\n"
 "--raw                    Show only messages hex values\n"
 "--net                    Enable networking\n"
 "--modeac                 Enable decoding of SSR Modes 3/A & 3/C\n"
@@ -491,6 +493,10 @@ void showHelp(void) {
 "--net-ro-rate <rate>     TCP raw output memory flush rate (default: 0)\n"
 "--lat <latitude>         Reference/receiver latitide for surface posn (opt)\n"
 "--lon <longitude>        Reference/receiver longitude for surface posn (opt)\n"
+"--receiver-height <alt>  Set altitude of receiver in feet/metres\n"
+"--azimuth <file>         Set file for azimuth data\n"
+"--azimuth-update <sec>	  Minimum time between updating azimuth file (default 600)\n"
+"--trail-buffer <num>  	  Trail buffer <num> numbers per plane. (MODES_TRAIL_ITEMS used per record)\n"
 "--fix                    Enable single-bits error correction using CRC\n"
 "--no-fix                 Disable single-bits error correction using CRC\n"
 "--no-crc-check           Disable messages with broken CRC (discouraged)\n"
@@ -624,6 +630,11 @@ int main(int argc, char **argv) {
             Modes.interactive = 1;
         } else if (!strcmp(argv[j],"--interactive-rows") && more) {
             Modes.interactive_rows = atoi(argv[++j]);
+        } else if (!strcmp(argv[j],"--interactive-refresh") && more) {
+            Modes.interactive_refresh_time = atoi(argv[++j]);
+	    if (Modes.interactive_refresh_time<100 || Modes.interactive_refresh_time > 5000) {
+		fprintf(stderr,"Refresh time should be between 100 and 5000 (ms)"); exit(1);
+	    }
         } else if (!strcmp(argv[j],"--interactive-ttl") && more) {
             Modes.interactive_display_ttl = atoi(argv[++j]);
         } else if (!strcmp(argv[j],"--lat") && more) {

--- a/dump1090.c
+++ b/dump1090.c
@@ -37,10 +37,30 @@ void sigintHandler(int dummy) {
     signal(SIGINT, SIG_DFL);  // reset signal handler - bit extra safety
     Modes.exit = 1;           // Signal to threads that we are done
 }
+
+/* ============================ Terminal handling  ========================== */
+
+
+/* Get the number of rows after the terminal changes size. */
+int getTermRows() {
+    struct winsize w;
+    ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+    return w.ws_row;
+}
+
+/* Handle resizing terminal. */
+void sigWinchCallback() {
+    signal(SIGWINCH, SIG_IGN);
+    Modes.interactive_rows = getTermRows();
+    interactiveShowData();
+    signal(SIGWINCH, sigWinchCallback);
+}
+
 //
 // =============================== Initialization ===========================
 //
 void modesInitConfig(void) {
+    int i;
     // Default everything to zero/NULL
     memset(&Modes, 0, sizeof(Modes));
 
@@ -54,11 +74,25 @@ void modesInitConfig(void) {
     Modes.net_output_beast_port   = MODES_NET_OUTPUT_BEAST_PORT;
     Modes.net_input_beast_port    = MODES_NET_INPUT_BEAST_PORT;
     Modes.net_http_port           = MODES_NET_HTTP_PORT;
-    Modes.interactive_rows        = MODES_INTERACTIVE_ROWS;
+    Modes.interactive_rows        = getTermRows();;
     Modes.interactive_delete_ttl  = MODES_INTERACTIVE_DELETE_TTL;
     Modes.interactive_display_ttl = MODES_INTERACTIVE_DISPLAY_TTL;
     Modes.fUserLat                = MODES_USER_LATITUDE_DFLT;
     Modes.fUserLon                = MODES_USER_LONGITUDE_DFLT;
+    Modes.trail_buffsz=MODES_TRAIL_BUFFSZ;
+    Modes.trail_mask=MODES_TRAIL_BUFFSZ-1;
+    Modes.rcv_hgt=0;
+    Modes.rcv_latkm=40008.0/360.0; /* polar curcumference / 360 */
+    Modes.rcv_lonkm=40075.16/360.0; /* equatorial circumference / 360,  Adjusted for lattitude later */
+    Modes.maxrange=calloc(361,sizeof(float));  /* shouldn't get a bearing of 360, but it's not worth a segv */
+    Modes.minele=calloc(361,sizeof(float));  /* shouldn't get a bearing of 360, but it's not worth a segv */
+    for(i=0;i<360;i++) {
+	Modes.maxrange[i]=0.0;
+	Modes.minele[i]=90.0;
+    }
+    Modes.azimuthfile=-1;
+    Modes.azi_refresh_time=600; /* 10 minutes */
+    Modes.azi_last_update=0;
 }
 //
 //=========================================================================
@@ -332,6 +366,99 @@ void snipMode(int level) {
         putchar(q);
     }
 }
+
+//
+// Azimuth file
+//
+#define AZ_BUF (360*80)
+
+int openAzimuthFile(const char * filename) 
+{
+    int fno;
+    int count,i,azimuth;
+    int line;
+    double lat,lon;
+    float range,ele;
+    char buffer[AZ_BUF];
+    char *p;
+    if (!filename || *filename=='\0') {
+        fprintf(stderr,"Empty file name for azimuth file\n");
+        exit(1);
+    }
+    fno=open(filename,O_CREAT|O_RDWR,S_IROTH | S_IWOTH | S_IRGRP | S_IWGRP | S_IWUSR | S_IRUSR);
+    line=0;
+    if (fno<0) {
+        perror(filename);
+        return(-1);
+    }
+    count=read(fno,buffer,AZ_BUF);
+    if (count>0) {
+        if(buffer[0] != '#') {
+            fprintf(stderr,"Non-empty azimuth file '%s' is not an azimuth file.\n",filename);
+            exit(1);
+        }
+        p=buffer+1;
+        line++;
+        if (sscanf(p,"%lf,%lf\n%n",&lat,&lon,&i)<2) {
+            fprintf(stderr,"Non-empty azimuth file '%s' does not parse like an azimuth file.\n",filename);
+            exit(1);
+        }
+        if ((lat != Modes.fUserLat) || (lon  !=Modes.fUserLon)) {
+            fprintf(stderr,"Azimuth file is for reciever position %lf,%lf but reciever set for %lf,%lf.\n",lat,lon,Modes.fUserLat,Modes.fUserLon);
+            exit(1);
+        }
+        p+=i;
+        count-=i;
+    }
+    while(count>5) { // Cannot have valid data in < 5 characters
+        line++;
+        if (sscanf(p,"%d,%f,%f\n%n",&azimuth,&range,&ele,&i)<3) {
+            if (sscanf(p,"%d,%f\n%n",&azimuth,&range,&i)<2) {
+	       fprintf(stderr,"Parse error on line %d of azimuth file\n",line);
+	    } else {
+		Modes.maxrange[azimuth]=range;
+		Modes.minele[azimuth]=90;
+	    }
+        } else {
+            Modes.maxrange[azimuth]=range;
+            Modes.minele[azimuth]=ele;
+        }
+        count-=i;
+        p+=i;
+    }
+    return(fno);
+}
+
+
+void updateAzimuthFile(void)
+{
+    int res; 
+    char buffer[AZ_BUF];
+    int count;
+    int i;
+    count=0;
+    res=lseek(Modes.azimuthfile,0,SEEK_SET);
+    if (res==-1 && errno==EBADF) {
+            Modes.azimuthfile=-1;
+    } else {
+        count+=snprintf(buffer,AZ_BUF-count,"#%lf,%lf\n",Modes.fUserLat,Modes.fUserLon);
+        for(i=0;(i<360 && count>10);i++) {
+            count+=snprintf(buffer+count,AZ_BUF-count,"%d,%.1f,%.2f\n",i,Modes.maxrange[i],Modes.minele[i]);
+        }
+        res=write(Modes.azimuthfile,buffer,count);
+        if (res<0) {
+            perror("Azimuth file");
+        }
+        res=ftruncate(Modes.azimuthfile,count);
+        if (res<0) {
+            perror("Azimuth file");
+        }
+        fsync(Modes.azimuthfile);
+    }
+}
+
+
+
 //
 // ================================ Main ====================================
 //
@@ -395,7 +522,9 @@ void showHelp(void) {
 // perform tasks we need to do continuously, like accepting new clients
 // from the net, refreshing the screen in interactive mode, and so forth
 //
+
 void backgroundTasks(void) {
+    time_t now;
     if (Modes.net) {
         modesReadFromClients();
     }    
@@ -409,12 +538,25 @@ void backgroundTasks(void) {
     if (Modes.interactive) {
         interactiveShowData();
     }
+
+    // No point checking time() multiple times a second, or if there's nothing new to write.
+    if (Modes.bgLoops++ > 60 && Modes.azimuthfile>=0 && Modes.azi_last_update > Modes.azi_last_write )  {
+	    now=time(NULL);
+	    if ( (now - Modes.azi_last_write) > Modes.azi_refresh_time) 
+	    {
+		updateAzimuthFile();
+		Modes.azi_last_write=now;
+	    }
+	    Modes.bgLoops=0;
+     }
 }
+
 //
 //=========================================================================
 //
 int main(int argc, char **argv) {
     int j;
+    char * azimuthfilename=NULL;
 
     // Set sane defaults
     modesInitConfig();
@@ -488,6 +630,23 @@ int main(int argc, char **argv) {
             Modes.fUserLat = atof(argv[++j]);
         } else if (!strcmp(argv[j],"--lon") && more) {
             Modes.fUserLon = atof(argv[++j]);
+        } else if (!strcmp(argv[j],"--trail-buffer") && more) {
+            uint32_t sz=atoi(argv[++j]);
+	    if (sz!=0 && sz<(2*MODES_TRAIL_ITEMS)) {
+                fprintf(stderr, "Trail buffer size must be 0 or %d or larger (and a power of 2)\n",2*MODES_TRAIL_ITEMS); exit(1);
+            }
+            if ((sz & (sz-1))) {
+                fprintf(stderr, "Trail buffer size must be power of 2 (256, 512, 1024, etc) or 0\n");
+                exit(1);
+            }
+            Modes.trail_buffsz = sz;
+            Modes.trail_mask=sz-1;
+	} else if (!strcmp(argv[j],"--receiver-height") && more) {
+            Modes.rcv_hgt = atoi(argv[++j]);
+        } else if (!strcmp(argv[j],"--azimuth") && more) {
+            azimuthfilename=strdup(argv[++j]);
+        } else if (!strcmp(argv[j],"--azimuth-update") && more) {
+            Modes.azi_refresh_time = atoi(argv[++j]);
         } else if (!strcmp(argv[j],"--debug") && more) {
             char *f = argv[++j];
             while(*f) {
@@ -531,6 +690,22 @@ int main(int argc, char **argv) {
             exit(1);
         }
     }
+
+    /* Setup for SIGWINCH for handling lines */
+    if (Modes.interactive == 1) signal(SIGWINCH, sigWinchCallback);
+
+    // Apply lat & Lon if specified.
+    if ((Modes.fUserLat != 0.0) || (Modes.fUserLon != 0.0)) {
+	Modes.rcv_lonkm*=cos(Modes.fUserLat*M_PI/180.0);
+	if (azimuthfilename) {
+	    time_t now = time(NULL);
+            Modes.azimuthfile = openAzimuthFile(azimuthfilename); 
+            Modes.azi_last_update=now;
+        } 
+    } else if (azimuthfilename) {
+            fprintf(stderr,"Azumuth file ignored as no receiver position set.\n");
+    }
+
 
     // Initialization
     modesInit();
@@ -637,3 +812,5 @@ int main(int argc, char **argv) {
 //
 //=========================================================================
 //
+
+

--- a/dump1090.h
+++ b/dump1090.h
@@ -37,7 +37,7 @@
 // MinorVer changes when additional features are added, but not for bug fixes (range 00-99)
 // DayDate & Year changes for all changes, including for bug fixes. It represent the release date of the update
 //
-#define MODES_DUMP1090_VERSION     "1.07.0710.13"
+#define MODES_DUMP1090_VERSION     "1.08.0125.14"
 
 // ============================= Include files ==========================
 
@@ -56,6 +56,7 @@
     #include <fcntl.h>
     #include <ctype.h>
     #include <sys/stat.h>
+    #include <sys/ioctl.h>
     #include "rtl-sdr.h"
     #include "anet.h"
 #else
@@ -161,6 +162,8 @@
 #define MODES_INTERACTIVE_ROWS          22      // Rows on screen
 #define MODES_INTERACTIVE_DELETE_TTL   300      // Delete from the list after 300 seconds
 #define MODES_INTERACTIVE_DISPLAY_TTL   60      // Delete from display after 60 seconds
+#define MODES_TRAIL_BUFFSZ 512               /* how many floats can be stored inthe trail buffer (power of 2) by default.  */
+#define MODES_TRAIL_ITEMS 2             /* How many floats per position. e.g. could theoretically store alt, but I don't right now.*/
 
 #define MODES_NET_MAX_FD             1024
 #define MODES_NET_INPUT_RAW_PORT    30001
@@ -216,7 +219,11 @@ struct aircraft {
     uint64_t      odd_cprtime;
     uint64_t      even_cprtime;
     double        lat, lon;       // Coordinated obtained from CPR encoded data
+    float        range, elevation; // distance (km) and angle above horizon
+    int          bearing; // Approx bearing 
     int           bFlags;         // Flags related to valid fields in this structure
+    float *trail; /* Rolling buffer for trail. */
+    uint16_t trailofs; /* offset into trail buffer of buffer start */
     struct aircraft *next;        // Next aircraft in our linked list
 };
 
@@ -293,10 +300,26 @@ struct {                             // Internal state
     int   mlat;                      // Use Beast ascii format for raw data output, i.e. @...; iso *...;
     int   interactive_rtl1090;       // flight table in interactive mode is formatted like RTL1090
 
+    //Aircraft trails, e.g. for browser reloads, infrequent updates
+    uint16_t trail_buffsz;	/* size of trail buffer, 2^^N */
+    uint16_t trail_mask;	/* 1-trailbuffsz */
+
     // User details
     double fUserLat;                // Users receiver/antenna lat/lon needed for initial surface location
     double fUserLon;                // Users receiver/antenna lat/lon needed for initial surface location
     int    bUserFlags;              // Flags relating to the user details
+    int rcv_hgt; 	/* Altitude of reciever */
+    double rcv_latkm;	/* approx km per degree latitude */
+    double rcv_lonkm;	/* km per degree longitude */
+
+    // Azimuth file
+    float * maxrange;                  /* Azimuth data */  
+    float * minele;                  /* Azimuth data */  
+    int azimuthfile;                 /* file handle for azimuth file, --azimuth option. */
+    int bgLoops;		/* No point checking the azimuth age multiple times a second  */
+    time_t azi_last_update;	       /* when the azimuth data was last changed */ 
+    time_t azi_last_write;	       /* when the azimuth file was last written */ 
+    int azi_refresh_time;	       /* How often to rewrite the azimuth file */
 
     // Interactive mode
     struct aircraft *aircrafts;

--- a/dump1090.h
+++ b/dump1090.h
@@ -324,6 +324,7 @@ struct {                             // Internal state
     // Interactive mode
     struct aircraft *aircrafts;
     uint64_t         interactive_last_update; // Last screen update in milliseconds
+    uint         interactive_refresh_time; // Screen update interval (milliseconds)
 
     // Statistics
     unsigned int stat_valid_preamble;

--- a/interactive.c
+++ b/interactive.c
@@ -72,6 +72,16 @@ struct aircraft *interactiveCreateAircraft(struct modesMessage *mm) {
             mm->bFlags  |= MODES_ACFLAGS_ALTITUDE_VALID;
         } 
     }
+    if (Modes.trail_buffsz) {
+	a->trail=malloc(sizeof(float)*Modes.trail_buffsz); /* test for valid pointer is done on access, so that we can continue even when memory is low. */
+	if (a->trail) {
+	    a->trail[0]=9999;
+	    a->trail[MODES_TRAIL_ITEMS]=9999;
+	}
+	a->trailofs=0;
+    } else {
+    	a->trail=NULL;
+    }
     return (a);
 }
 //
@@ -459,6 +469,8 @@ void interactiveRemoveStaleAircrafts(void) {
             else
                 prev->next = next;
 
+            if (a->trail)
+                free(a->trail);
             free(a);
             a = next;
         } else {

--- a/interactive.c
+++ b/interactive.c
@@ -338,8 +338,8 @@ void interactiveShowData(void) {
     char progress;
     char spinner[4] = "|/-\\";
 
-    // Refresh screen every (MODES_INTERACTIVE_REFRESH_TIME) miliseconde
-    if ((mstime() - Modes.interactive_last_update) < MODES_INTERACTIVE_REFRESH_TIME)
+    // Refresh screen every (Modes.interactive_refresh_time) miliseconde
+    if ((mstime() - Modes.interactive_last_update) < Modes.interactive_refresh_time)
        {return;}
 
     Modes.interactive_last_update = mstime();    

--- a/mode_s.c
+++ b/mode_s.c
@@ -1932,6 +1932,71 @@ double cprDlonFunction(double lat, int fflag, int surface) {
 }
 //
 //=========================================================================
+// Perform crude range calculations. 
+// Dosn't work near the poles, but I don't want to do the spherical trig.
+//
+void calcRange(struct aircraft *a)
+{
+    double range;
+    double bearing;
+    double kmalt;
+    double dns=(a->lat - Modes.fUserLat); /* North +ve */
+    double dew=(a->lon - Modes.fUserLon);/* East is +ve */
+
+    // Date line correction
+    if (dew<-270) dew = dew+360;
+    if (dew>270) dew= dew-360;
+
+    //Lat,lon into distance, Make gross assumption that the world is flat
+    dns = dns * Modes.rcv_latkm;
+    dew = dew * Modes.rcv_lonkm; 
+    range=sqrt(dew*dew+dns*dns);
+
+    if (range<1000) {  /* Sanity check */
+	if (Modes.metric) {
+	    kmalt =(a->altitude - Modes.rcv_hgt)/1e3;
+	} else { 
+	    kmalt=(a->altitude - Modes.rcv_hgt)/ 3.2828e3;
+	}
+
+	a->range=range;
+	bearing=180*atan2(dew,dns)/M_PI; /* Reference is north/south therefore "y" axis is east/west */
+	if (bearing<-0.5) { /* the cast truncates decimal portion, so +/- 0.5 */
+	    a->bearing=360+((int)(bearing-0.5));
+	} else {
+	    a->bearing=(int)(bearing+0.5);
+	}
+	if (range > Modes.maxrange[a->bearing]) {
+	    Modes.maxrange[a->bearing]=range;
+	    Modes.azi_last_update=a->seen;
+	}
+	if (kmalt<(0.13835*range)) {
+	    //atan2 is quite costly, but can use use small angle approximation,
+	    //as error of 0.05 degrees occurs at about 0.13835. Below this 
+	    //there is no difference at 1dp.
+	    a->elevation=180*kmalt/(M_PI*range);
+        } else {
+	    a->elevation=180*atan2(kmalt,range)/M_PI;
+	}
+	if (a->elevation < Modes.minele[a->bearing]) {
+	    Modes.minele[a->bearing]=a->elevation;
+	    Modes.azi_last_update=a->seen;
+	}
+    }
+}
+
+//
+// Trail data for pre-loading web page.
+//
+void UpdateTrail(struct aircraft *a) {
+    /* printf("%d -> ",a->trailofs); */
+    /* printf("%d\n",a->trailofs); */
+    a->trailofs=(a->trailofs-MODES_TRAIL_ITEMS) & Modes.trail_mask;
+    a->trail[a->trailofs]=a->lat;
+    a->trail[a->trailofs+1]=a->lon;
+    a->trail[(a->trailofs-MODES_TRAIL_ITEMS) & Modes.trail_mask]=9999; // Just in case the buffer has looped
+}
+
 //
 // This algorithm comes from:
 // http://www.lll.lu/~edward/edward/adsb/DecodingADSBposition.html.
@@ -1969,6 +2034,14 @@ void decodeCPR(struct aircraft *a, int fflag, int surface) {
     // Check that both are in the same latitude zone, or abort.
     if (cprNLFunction(rlat0) != cprNLFunction(rlat1)) return;
 
+
+    // Put the old position into the trail, if it's a real position.
+    // the trail is stored in most recent first order.
+    if (a->trail && !(a->lat==0.0 && a->lon==0.0) ) {
+	UpdateTrail(a);
+    }
+
+
     // Compute ni and the Longitude Index "m"
     if (fflag) { // Use odd packet.
         int ni = cprNFunction(rlat1,1);
@@ -1993,6 +2066,10 @@ void decodeCPR(struct aircraft *a, int fflag, int surface) {
     a->seenLatLon      = a->seen;
     a->timestampLatLon = a->timestamp;
     a->bFlags         |= (MODES_ACFLAGS_LATLON_VALID | MODES_ACFLAGS_LATLON_REL_OK);
+
+    if (Modes.bUserFlags & MODES_USER_LATLON_VALID) { 
+	calcRange(a);
+    }
 }
 //
 //=========================================================================
@@ -2061,12 +2138,19 @@ int decodeCPRrelative(struct aircraft *a, int fflag, int surface) {
         return (-1);                               // Time to give up - Longitude error
     }
 
+    if (a->trail && !(a->lat==0.0 && a->lon==0.0) ) {
+	UpdateTrail(a);
+    }
+
     a->lat = rlat;
     a->lon = rlon;
 
     a->seenLatLon      = a->seen;
     a->timestampLatLon = a->timestamp;
     a->bFlags         |= (MODES_ACFLAGS_LATLON_VALID | MODES_ACFLAGS_LATLON_REL_OK);
+    if (Modes.bUserFlags & MODES_USER_LATLON_VALID) { 
+	calcRange(a);
+    }
     return (0);
 }
 //

--- a/net_io.c
+++ b/net_io.c
@@ -783,7 +783,7 @@ int handleHTTPRequest(struct client *c, char *p) {
     // "/" -> Our google map application.
     // "/data.json" -> Our ajax request to update planes.
     // "/azi.json" -> ajax request for azimuth data
-    // "/config2.js" -> runtime configuration
+    // "/runtime.js" -> runtime configuration
     char * start;
 
     if ( (start=strstr(url, "/data.json"))!=0 ) {

--- a/net_io.c
+++ b/net_io.c
@@ -558,12 +558,32 @@ int decodeHexMessage(struct client *c, char *hex) {
 //
 // Return a description of planes in json. No metric conversion
 //
-char *aircraftsToJson(int *len) {
+char *aircraftsToJson(int *len,const char *trailspec) {
+    // Trailspec is either "N,hexid" or "hexid" Hexid may be a valid id or "*"
     time_t now = time(NULL);
+    char * trailidstr;
+    int trailid;
+    int traillen;
     struct aircraft *a = Modes.aircrafts;
     int buflen = 1024; // The initial buffer is incremented as needed
     char *buf = (char *) malloc(buflen), *p = buf;
     int l;
+    trailid=-1; //magic code: no trails
+    traillen=Modes.trail_buffsz+1;  /* all the data by default */
+    if (trailspec) {
+	trailidstr=strstr(trailspec,",");
+	if (trailidstr) {
+	    trailidstr++;
+	    traillen=strtol(trailspec,NULL,10);
+	} else {
+	    trailidstr=trailspec;
+	}
+	if (*trailidstr=='*') {
+		trailid=0; // magic number: all trails
+	} else {
+		trailid=strtol(trailidstr,NULL,16);
+	}
+    } 
 
     l = snprintf(p,buflen,"[\n");
     p += l; buflen -= l;
@@ -588,19 +608,52 @@ char *aircraftsToJson(int *len) {
         l = snprintf(p,buflen,
             "{\"hex\":\"%06x\", \"squawk\":\"%04x\", \"flight\":\"%s\", \"lat\":%f, "
             "\"lon\":%f, \"validposition\":%d, \"altitude\":%d,  \"vert_rate\":%d,\"track\":%d, \"validtrack\":%d,"
-            "\"speed\":%d, \"messages\":%ld, \"seen\":%d},\n",
+            "\"speed\":%d, \"messages\":%ld, \"seen\":%d, \"seenLL\":%d, \"range\":%.1f, \"bearing\":%d, \"elevation\":%.1f",
             a->addr, a->modeA, a->flight, a->lat, a->lon, position, a->altitude, a->vert_rate, a->track, track,
-            a->speed, a->messages, (int)(now - a->seen));
+            a->speed, a->messages, (int)(now - a->seen), (int)(now - a->seenLatLon), a->range, a->bearing, a->elevation);
         p += l; buflen -= l;
-        
-        //Resize if needed
+	// Haven't finished this plane yet, but still Resize if needed
         if (buflen < 256) {
             int used = p-buf;
             buflen += 1024; // Our increment.
             buf = (char *) realloc(buf,used+buflen);
             p = buf+used;
         }
-        
+	/* If there's a trail, then check the value of passed trailid. If
+	 * it's '*' or matches this hexaddr, then print the trail data too. */
+	if (Modes.trail_buffsz==0 || a->trail==NULL || trailid<0 || (trailid != 0 && (unsigned) trailid != a->addr)) {
+	    // No trail to add; No point calling snprintf either.
+	    p[0]='}';
+	    p[1]=',';
+	    p[2]='\n';
+	    p+=3;
+	    buflen-=3;
+	} else {
+	    int idx;
+	    int count;
+	    count=0;
+	    l = snprintf(p,buflen,",\"trail\":[");
+	    p += l; buflen -= l;
+	    /* End of data signaled by 9999 in the lat/long. the trial buffer is a rolling buffer, a power of 2 long  */
+	    for(idx=a->trailofs;count<traillen && a->trail[idx]<181 && a->trail[idx]>-181 ;idx=(idx+MODES_TRAIL_ITEMS)&Modes.trail_mask) {
+		count++;
+		l=snprintf(p,buflen,"[%.5f,%.5f],",a->trail[idx],a->trail[idx+1]);
+		p += l; buflen -= l;
+		if (buflen < 256) {
+		    int used = p-buf;
+		    buflen += 1000; /* increment. (not power of 2, in case of malloc-lib housekeeping) */
+		    buf = realloc(buf,used+buflen);
+		    p = buf+used;
+		}
+	    }
+	    if (count) { /* Overwrite final comma if its there */
+		p--;
+		buflen++;
+	    }
+	    l=snprintf(p,buflen,"]},\n");
+	    p += l; buflen -= l;
+	}
+    
         a = a->next;
     }
 
@@ -617,6 +670,59 @@ char *aircraftsToJson(int *len) {
     *len = p-buf;
     return buf;
 }
+
+//
+//=========================================================================
+//
+// Return Azimuth data as JSON, No non-metric conversion.
+//
+char *aziToJson(int *len) {
+    int buflen = 10240; /* initial buffer length */
+    char *buf = malloc(buflen), *p = buf;
+    int l;
+    l = snprintf(p,buflen,"[\n");
+    p += l; buflen -= l;
+    int i;
+    for(i=0;(i<360 && buflen>12);i++) {
+	double lat,lon;
+	double bearing=i*M_PI/180.0;
+	
+	lat=Modes.fUserLat+(Modes.maxrange[i]*cos(bearing))/Modes.rcv_latkm; /* N +ve */
+	lon=Modes.fUserLon+(Modes.maxrange[i]*sin(bearing))/Modes.rcv_lonkm; /* E +ve */
+
+	l = snprintf(p,buflen,"[%.6f,%.6f],",lat,lon);
+	buflen-=l;
+	p+=l;
+	if (buflen < 256) {
+	    int used = p-buf;
+	    buflen += 1024; /* Our increment. */
+	    buf = realloc(buf,used+buflen);
+	    p = buf+used;
+	}
+    }
+    p-=1;buflen+=1;
+    l = snprintf(p,buflen,"]\n");
+    p += l; buflen -= l;
+    *len = p-buf;
+    return buf;
+}
+//
+//=========================================================================
+//
+// Javascript fragment to alter default settings with actual runtime values.
+//
+char *runtimeToJS(int *len) {
+    int buflen = 1024; /* initial buffer length */
+    char *buf = malloc(buflen), *p = buf;
+    int l;
+    if (Modes.bUserFlags & MODES_USER_LATLON_VALID) {
+	l = snprintf(p,buflen,"CONST_ZOOMLVL=7;\nCONST_CENTERLAT=SiteLat=%f;\nCONST_CENTERLON=SiteLon=%f;\nSiteShow=true;\n",Modes.fUserLat,Modes.fUserLon);
+	p += l; buflen -= l;
+    }
+    *len = p-buf;
+    return(buf);
+}
+
 //
 //=========================================================================
 //
@@ -673,12 +779,23 @@ int handleHTTPRequest(struct client *c, char *p) {
         snprintf(getFile, sizeof getFile, "%s/%s", HTMLPATH, url);
     }
 
-    // Select the content to send, we have just two so far:
+    // Select the content to send, we have just four so far:
     // "/" -> Our google map application.
     // "/data.json" -> Our ajax request to update planes.
-    if (strstr(url, "/data.json")) {
-        content = aircraftsToJson(&clen);
-        //snprintf(ctype, sizeof ctype, MODES_CONTENT_TYPE_JSON);
+    // "/azi.json" -> ajax request for azimuth data
+    // "/config2.js" -> runtime configuration
+    char * start;
+
+    if ( (start=strstr(url, "/data.json"))!=0 ) {
+	if (*(start+10) =='?' && *(start+11) !='\0') {
+	    content = aircraftsToJson(&clen,start+11);
+	} else {
+	    content = aircraftsToJson(&clen,NULL);
+	}
+    } else if (strstr(url, "/azi.json")) {
+    	content = aziToJson(&clen);
+    } else if (strstr(url,"/runtime.js")) {
+    	content = runtimeToJS(&clen);
     } else {
         struct stat sbuf;
         int fd = -1;

--- a/public_html/gmap.html
+++ b/public_html/gmap.html
@@ -6,6 +6,7 @@
 		<script src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
 		<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false&libraries=geometry"></script>
 		<script type="text/javascript" src="config.js"></script>
+		<script type="text/javascript" src="runtime.js"></script>
 		<script type="text/javascript" src="planeObject.js"></script>
 		<script type="text/javascript" src="options.js"></script>
 		<script type="text/javascript" src="extension.js"></script>
@@ -16,36 +17,55 @@
 	</head>
 	<body onload="initialize()">
 		<div id="dialog-modal" title="Basic modal dialog" style="display:none;">
-			<p>The settings feature is coming soon. Keep checking GitHub.</p>
+			<form id="option_form" onsubmit="{return(false)}">
+			    Updates frequency <input name=updfreq type=text size=2 value=1 onkeyup="setfreq(this.value);"> seconds<br>
+			    <select name=traildisplay onchange="funcOptionsChanged()">
+
+				<option value=selected>Only display trail of selected plane</option>
+				<option value=clean selected>Display trails of all current planes</option>
+				<option value=showall>Also show old trails</option>
+			    </select>
+			    <div id=extratrailoption onchange="funcOptionsChanged">
+				<input type=checkbox name="remember" value=1 checked> Remember trails for planes that go off scope
+			    </div>
+			    <select name=trailmode>
+				<option value="all" selected>Request tracks for all flights</option>
+				<option value="selected">Request track for selected flight</option>
+				<option value="off">No track requests (browser's history only)</option>
+			    </select>
+			</form>
+			[<span onclick="show_azi();">Show azimuth plot</span>]<br>
+			<div id=aziplotlist>
+			</div>
 		</div>
 		<div id="map_container">
-			<div id="map_canvas"></div>
-		</div>
-		<div id="sidebar_container">
-			<div id="sidebar_canvas">
-				<div id="timestamps" style="align: center">
-					<table width="100%"><tr>
-						<td>Local Time</td>
-						<td>
-							<canvas id="localclock" class="CoolClock:classic:40"></canvas>
-						</td>
-						<td>UTC Time</td>
-						<td>
-							<canvas id="gmtclock" class="CoolClock:classic:40::0"></canvas>
-						</td>
-					</tr></table>
-				</div>
-				<div id="sudo_buttons">
-					<table width="100%"><tr>
-						<td width="150" style="text-align: center;" class="pointer">
-						    [ <span onclick="resetMap();">Reset Map</span> ]
-						</td>
-						<td>&nbsp;</td>
-						<td width="150" style="text-align: center;" id="setings_button" class="pointer">
-						    [ <span onclick="optionsModal();">Settings</span> ]
-						</td>
-					</tr></table>
-				</div>
+		    <div id="map_canvas"></div>
+	    </div>
+	    <div id="sidebar_container">
+		    <div id="sidebar_canvas">
+			    <div id="timestamps" style="align: center">
+				    <table width="100%"><tr>
+					    <td>Local Time</td>
+					    <td>
+						    <canvas id="localclock" class="CoolClock:classic:40"></canvas>
+					    </td>
+					    <td>UTC Time</td>
+					    <td>
+						    <canvas id="gmtclock" class="CoolClock:classic:40::0"></canvas>
+					    </td>
+				    </tr></table>
+			    </div>
+			    <div id="sudo_buttons">
+				    <table width="100%"><tr>
+					    <td width="150" style="text-align: center;" class="pointer">
+						[ <span onclick="resetMap();">Reset Map</span> ]
+					    </td>
+					    <td>&nbsp;</td>
+					    <td width="150" style="text-align: center;" id="setings_button" class="pointer">
+						[ <span onclick="optionsModal();">Settings</span> ]
+					    </td>
+				    </tr></table>
+			    </div>
 
 				<div id="plane_detail"></div>
 				<div id="options"></div>

--- a/public_html/options.js
+++ b/public_html/options.js
@@ -5,7 +5,7 @@ function optionsInitalize() {
 	// Write your initalization here
 	// Gets called just before the 1-sec function call loop is setup
 	$( "#dialog-modal" ).dialog({
-		height: 140,
+		height: 340,
 		modal: true,
 		autoOpen: false,
 		closeOnEscape: false

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -838,7 +838,7 @@ function funcOptionsChanged() {
 
 function selectPlaneByHex(hex) {
 	// If SelectedPlane has something in it, clear out the selected
-	if (SelectedPlane != null && Planes[SelectedPlane && Planes[SelectedPlane]]) {
+	if (SelectedPlane != null && Planes[SelectedPlane]) {
 		Planes[SelectedPlane].is_selected = false;
 		if (form.elements['traildisplay'].value == 'selected') {
 			Planes[SelectedPlane].funcClearLine();

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -11,16 +11,189 @@ var iSortCol=-1;
 var bSortASC=true;
 var bDefaultSortASC=true;
 var iDefaultSortCol=3;
+var Azimuths=[]; /* Azimuth paths */
+var tabSin=[]; /* Lookup array [0-360] for Sin(degrees) */
+var tabCos=[]; /* as above. */
+var latPerNm=1.0/60.0;  /* Approx translation from Nm to delta latitude: Historically 1Nm=1arcMin. This is good enough for guesses */
+var lonPerNm; /* set later, and updated on changes to CenterLat */
+var wait=0;
+var waitsecs=10; // Initial query frequency
+var oldwait=1; // Default query frequency, once page is loaded, assuming no user settings.
+var hidden, visibilityChange;
+var traillen=10000; // How many trail pointes to ask for - initially all.
+var form=null; // HTML form element
+var trailDisplay='clean';
+var trailRemember=true;
+////////////////////////////////////////////////////////////
+// 
+// Alter the update frequency.  Reduces load on server and client machines
+//
+
+// Manual control
+function setfreq(n) {
+    waitsecs=n;
+}
+
+//Automatic update control:
+// If the page is hidden, don't update so often.
+// if the page is shown, restore update frequency
+function handleVisibilityChange() {
+  if (document[hidden]) {
+    oldwait=waitsecs;
+    if (waitsecs<45) {
+	waitsecs=45;
+    }
+  } else {
+    waitsecs=oldwait;
+  }
+}
+
+// Cross-browser shim so we can notice when the page is displayed or not.
+
+if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support 
+  hidden = "hidden";
+  visibilityChange = "visibilitychange";
+} else if (typeof document.mozHidden !== "undefined") {
+  hidden = "mozHidden";
+  visibilityChange = "mozvisibilitychange";
+} else if (typeof document.msHidden !== "undefined") {
+  hidden = "msHidden";
+  visibilityChange = "msvisibilitychange";
+} else if (typeof document.webkitHidden !== "undefined") {
+  hidden = "webkitHidden";
+  visibilityChange = "webkitvisibilitychange";
+}
+
+
+// Handle page visibility change   
+document.addEventListener(visibilityChange, handleVisibilityChange, false);
+
+
 
 // Get current map settings
 CenterLat = Number(localStorage['CenterLat']) || CONST_CENTERLAT;
 CenterLon = Number(localStorage['CenterLon']) || CONST_CENTERLON;
 ZoomLvl   = Number(localStorage['ZoomLvl']) || CONST_ZOOMLVL;
 
+lonPerNm=latPerNm/Math.sin(CenterLat*3.14159/180) ; /* Very rough translation from Nm to delta longitude.  */
+
+///////////////////////////////////////////////////////////////
+//
+// Overlay of aziumuth plot (maximum range in different directions).
+// Allow several to be plotted (and deleted) so that comparisons can be made
+//
+// First the list control:
+function updateAziList() {
+    var div=document.getElementById("aziplotlist");
+    var fmt="[<span onclick=\"clear_azi(_SEQ_);\">Remove azimuth plot _TITLE_</span>]<br>";
+    var html="";
+    for(var i=Azimuths.length-1; i>=0; i--) {
+    	var fragment=fmt.replace(/_SEQ_/g,i);
+    	html += fragment.replace(/_TITLE_/g,Azimuths[i].title);
+    }
+    div.innerHTML=html;
+}
+
+function clear_azi(n) {
+    if (n>=Azimuths.length) {
+	    n=Azimuths.length-1;
+    }
+    Azimuths[n].line.setMap(null);
+    Azimuths.splice(n,1);
+    updateAziList();
+}
+
+//Callback from JSON call.
+//TODO: alter here and server to include historical plots to be loaded 
+function newazi(data) {
+    var AziCoordinates = [];
+    for (var j=0;j<data.length;j++) {
+	var lat,lon;
+	lat=data[j][0];
+	lon=data[j][1];
+	AziCoordinates.push(new google.maps.LatLng(lat,lon)); 
+    }
+    Azimuths.push( {
+    	line: new google.maps.Polyline({ path: AziCoordinates, strokeColor: "#007f00", strokeOpacity: 1.0, strokeWeight: 1 }),
+	title: new Date().toString(),
+	});
+    Azimuths[Azimuths.length-1].line.setMap(GoogleMap);
+    updateAziList();
+}
+
+function show_azi() {
+    $.getJSON('/azi.json',function(data) {newazi(data)} );
+}
+
+
+
+////////////////////////////////////////////////////
+//
+// Manual hide / clean up of tracks from vanished and active planes
+//
+
+
+function hide_tracks() {
+    if (deadPaths.length) {
+	for(var i=deadPaths.length-1; i>=0; i--) {
+	    deadPaths[i].setMap(null);
+	}
+    }
+}
+
+function cleanup_tracks() {
+    if (deadPaths.length) {
+	for(var i=deadPaths.length-1; i>=0; i--) {
+	    deadPaths[i].setMap(null);
+	    deadPaths[i]=null;
+	}
+    }
+    deadPaths.length=0;
+    for(var p in Planes) {
+	if (Planes[p].line) {
+	    Planes[p].line.setMap(null);
+	}
+    }
+
+}
+
+// What trail data do we want to fetch from ffetchData?
+function getFetchOptions() {
+	var arg="";
+	if (!form) {
+			form=document.getElementById("option_form");
+	}
+	var eles=form.elements;
+	var mode;
+	mode= eles['trailmode'].value;
+	if (mode=="off") {
+		arg="";
+		traillen=10000;
+	} else if (mode=="selected") {
+		if (typeof SelectedPlane !== 'undefined' && SelectedPlane != "ICAO" && SelectedPlane != null) {
+			arg=SelectedPlane;
+			if (traillen<900)  {
+				arg="?" + traillen+","+SelectedPlane;
+			}
+			traillen=2+wait; // Enough positions to hopefully avoid gaps, but not silly quantities of useless data
+		} 
+	} else { //All planes
+		arg="?*";
+		if (traillen<900)  {
+			arg="?" + traillen+",*";
+		}
+		traillen=2+wait;
+	}
+	return(arg);
+}
+
 function fetchData() {
-	$.getJSON('/dump1090/data.json', function(data) {
+	var url='/dump1090/data.json' + getFetchOptions();
+	//console.log(url);
+	$.getJSON(url, function(data) {
 		PlanesOnMap = 0
 		SpecialSquawk = false;
+		var now=new Date().getTime();
 		
 		// Loop through all the planes in the data packet
 		for (var j=0; j < data.length; j++) {
@@ -43,7 +216,7 @@ function fetchData() {
             }
 
 			// Call the function update
-			plane.funcUpdateData(data[j]);
+			plane.funcUpdateData(data[j],now);
 			
 			// Copy the plane into Planes
 			Planes[plane.icao] = plane;
@@ -158,6 +331,7 @@ function initialize() {
     google.maps.event.addListener(GoogleMap, 'center_changed', function() {
         localStorage['CenterLat'] = GoogleMap.getCenter().lat();
         localStorage['CenterLon'] = GoogleMap.getCenter().lng();
+		lonPerNm=latPerNm/Math.sin(CenterLat*3.14159/180) ; /* Very rough translation from Nm to delta longitude.  */
     });
     
     google.maps.event.addListener(GoogleMap, 'zoom_changed', function() {
@@ -186,11 +360,38 @@ function initialize() {
             }
         }
 	}
+
+	/* Populate the lookup tables */
+	var deg=3.14159/180;
+	for(var i=89;--i;) {
+		var sinI=Math.sin(i*deg);
+		tabSin[180-i]=tabSin[i]=sinI;
+		tabSin[360-i]=tabSin[i+180]=-sinI;
+		tabCos[90-i]=tabCos[270+i]=sinI;
+		tabCos[i+90]=tabCos[270-i]=-sinI;
+	}
+	/* endpoints */
+	tabCos[90]=tabCos[270]=tabSin[0]=tabSin[360]=tabSin[180]=0;
+	tabCos[0]=tabCos[360]=tabSin[90]=1;
+	tabSin[270]=tabCos[180]-1;
+
+    	funcOptionsChanged(); // check current options. 
 	
 	// These will run after page is complitely loaded
 	$(window).load(function() {
-        $('#dialog-modal').css('display', 'inline'); // Show hidden settings-windows content
-    });
+	    $('#dialog-modal').css('display', 'inline'); // Show hidden settings-windows content
+	});
+
+	// After an initial page load time, set waitsecs to the normal value
+	setTimeout(function() {
+	    if (!form) {
+		form=document.getElementById("option_form");
+	    }
+	    if ( +form.elements['updfreq'].value) {
+		oldwait= +form.elements['updfreq'].value;
+	    }
+	    waitsecs=oldwait;
+	},5000);
 
 	// Load up our options page
 	optionsInitalize();
@@ -200,11 +401,15 @@ function initialize() {
 	
 	// Setup our timer to poll from the server.
 	window.setInterval(function() {
+	    wait++;
+	    if (wait >= waitsecs) {
 		fetchData();
+		wait=0;
 		refreshTableInfo();
 		refreshSelected();
 		reaper();
 		extendedPulse();
+	    }
 	}, 1000);
 }
 
@@ -212,7 +417,7 @@ function initialize() {
 function reaper() {
 	PlanesToReap = 0;
 	// When did the reaper start?
-	reaptime = new Date().getTime();
+	var reaptime = new Date().getTime();
 	// Loop the planes
 	for (var reap in Planes) {
 		// Is this plane possibly reapable?
@@ -222,6 +427,27 @@ function reaper() {
 			// Due to loss of signal or other reasons
 			if ((reaptime - Planes[reap].updated) > 300000) {
 				// Reap it.
+				plane=Planes[reap];
+				if (plane.guess) {
+					plane.guess.setMap(null);
+					plane.guess=null;
+				}
+				if (plane.line) {
+			     	    // Unlikely to reach here with trailDisplay!=showall, but just in case..
+				    plane.line.setOptions({strokeColor: "#7f0000", map:(trailDisplay=='showall')?GoogleMap:null});
+				    deadPaths.push(plane.line);
+				    plane.line=null;
+				} else { 
+			            if (trailRemember) {
+					deadPaths.push(new google.maps.Polyline({
+					    strokeColor: '#7f0000',
+					    strokeOpacity: 1.0,
+					    strokeWeight: 1,
+					    map: (trailDisplay=='showall')?GoogleMap:null,
+					    path: plane.trackline
+					}));
+				    }
+				}
 				delete Planes[reap];
 			}
 			PlanesToReap++;
@@ -232,7 +458,7 @@ function reaper() {
 // Refresh the detail window about the plane
 function refreshSelected() {
     var selected = false;
-	if (typeof SelectedPlane !== 'undefined' && SelectedPlane != "ICAO" && SelectedPlane != null) {
+	if (typeof SelectedPlane !== 'undefined' && SelectedPlane != "ICAO" && SelectedPlane != null && Planes[SelectedPlane]) {
     	selected = Planes[SelectedPlane];
     }
 	
@@ -404,7 +630,13 @@ function refreshTableInfo() {
 	html += '<td onclick="setASC_DESC(\'6\');sortTable(\'tableinfo\',\'6\');" ' +
 	    'align="right">Msgs</td>';
 	html += '<td onclick="setASC_DESC(\'7\');sortTable(\'tableinfo\',\'7\');" ' +
-	    'align="right">Seen</td></thead><tbody>';
+	    'align="right">Seen</td>';
+	html += '<td onclick="setASC_DESC(\'8\');sortTable(\'tableinfo\',\'7\');" ' +
+	    'align="right">Azi</td>';
+	html += '<td onclick="setASC_DESC(\'9\');sortTable(\'tableinfo\',\'7\');" ' +
+	    'align="right">Ele</td>';
+	html += '<td onclick="setASC_DESC(\'10\');sortTable(\'tableinfo\',\'7\');" ' +
+	    'align="right">Range</td></thead><tbody>';
 	for (var tablep in Planes) {
 		var tableplane = Planes[tablep]
 		if (!tableplane.reapable) {
@@ -458,6 +690,9 @@ function refreshTableInfo() {
     	    html += '</td>';
 			html += '<td align="right">' + tableplane.messages + '</td>';
 			html += '<td align="right">' + tableplane.seen + '</td>';
+			html += '<td align="right">' + tableplane.bearing + '</td>';
+			html += '<td align="right">' + tableplane.elevation + '</td>';
+			html += '<td align="right">' + tableplane.range + '</td>';
 			html += '</tr>';
 		}
 	}
@@ -548,15 +783,75 @@ function sortTable(szTableID,iCol) {
 	aStore=null;
 }
 
+function funcOptionsChanged() {
+    if (!form) {
+	    form=document.getElementById("option_form");
+    }
+    trailDisplay=form.elements['traildisplay'].value;
+    if (form.elements['remember']) {
+	trailRemember=form.elements['remember'].value;
+    } else {
+	trailRemember=true;
+    }
+    if (trailDisplay=='showall') {
+	trailRemember=true;
+    }
+    var cbHTML="<input type=checkbox name=remember value=1 " + (trailRemember?'checked':'') + "> Remember trails for planes that go off scope";
+    var div=document.getElementById("extratrailoption");
+    if (trailDisplay=='selected')  {
+        traillen=10000; /* ask for everything next update */
+	div.innerHTML=cbHTML;
+	for(var p in Planes) {
+	    if (!Planes[p].is_selected) {
+		    Planes[p].funcClearLine();
+	    } else {
+	    	Planes[p].funcShowLine();
+	    }
+	}
+	for(var t=deadPaths.length-1;t>=0; t--) {
+	    deadPaths[t].setMap(none);
+	}
+    } else if (trailDisplay=='clean') { // Only active planes.
+	div.innerHTML=cbHTML;
+        for(var p in Planes) {
+	    if (Planes[p].reapable) {
+		Planes[p].funcClearLine();
+	    } else {
+		Planes[p].funcShowLine();
+	    } 
+	}
+	for(var t=deadPaths.length-1;t>=0; t--) {
+	    deadPaths[t].setMap(null);
+	}
+    } else { // trailDisplay=='showall' : Show all planes AND deadPaths
+	div.innerHTML='[<span onclick="hide_tracks()">Hide oldest tracks</span>]<br>[<span onclick="cleanup_tracks()">Clean up inactive tracks</span>]<BR>';
+	for(var p in Planes) {
+	    if (!Planes[p].line) {
+		Planes[p].funcShowLine();	
+	    } 
+	}
+	for(var t=deadPaths.length-1;t>=0; t--) {
+	    deadPaths[t].setMap(GoogleMap);
+	}
+    }
+}
+
 function selectPlaneByHex(hex) {
 	// If SelectedPlane has something in it, clear out the selected
-	if (SelectedPlane != null) {
+	if (SelectedPlane != null && Planes[SelectedPlane && Planes[SelectedPlane]]) {
 		Planes[SelectedPlane].is_selected = false;
-		Planes[SelectedPlane].funcClearLine();
+		if (form.elements['traildisplay'].value == 'selected') {
+			Planes[SelectedPlane].funcClearLine();
+		} else {
+			Planes[SelectedPlane].funcDeselectLine();
+		}
 		Planes[SelectedPlane].markerColor = MarkerColor;
 		// If the selected has a marker, make it not stand out
 		if (Planes[SelectedPlane].marker) {
 			Planes[SelectedPlane].marker.setIcon(Planes[SelectedPlane].funcGetIcon());
+		}
+		if (Planes[SelectedPlane].guess) {
+			Planes[SelectedPlane].guess.setIcon(Planes[SelectedPlane].getIconForGuess());
 		}
 	}
 
@@ -569,6 +864,9 @@ function selectPlaneByHex(hex) {
 		if (Planes[SelectedPlane].marker) {
 			Planes[SelectedPlane].funcUpdateLines();
 			Planes[SelectedPlane].marker.setIcon(Planes[SelectedPlane].funcGetIcon());
+		}
+		if (Planes[SelectedPlane].guess) {
+			Planes[SelectedPlane].guess.setIcon(Planes[SelectedPlane].getIconForGuess());
 		}
 	} else { 
 		SelectedPlane = null;
@@ -587,6 +885,7 @@ function resetMap() {
     CenterLat = Number(localStorage['CenterLat']) || CONST_CENTERLAT;
     CenterLon = Number(localStorage['CenterLon']) || CONST_CENTERLON;
     ZoomLvl   = Number(localStorage['ZoomLvl']) || CONST_ZOOMLVL;
+    lonPerNm=latPerNm/Math.sin(CenterLat*3.14159/180) ; /* Very rough translation from Nm to delta longitude.  */
     
     // Set and refresh
 	GoogleMap.setZoom(parseInt(ZoomLvl));


### PR DESCRIPTION
Hi, 
  I'd been slowly making  a number of modifications to my fork of antirez's
code-base which I've now re-written and improved with a bit more thought onto 
a fork of your repo.
I did rather apply them all at once though, so most of my commits squashed here
are bug-fixing / re-factoring rather than applying the different extra features in a
logical manner.  Sorry it's such a big patch, that's why.

New Features:
-   Map gets centred on user's runtime-specified position
-   Calculation / display of range, azimuth and elevation of each aircraft.
-   Azimuth / lowest angle file (for plotting e.g. with gnuplot) 
-   Azimuth plot(s) on map
-   Adjustable polling of server
-   Server remembers partial trails of aircraft
-   Selection of trail display : selected/active/reapable & reaped
-   Browser incrementally calculates (and shows) a guess of plane's location
  based on speed/direction if updates are slow.

Rationale / description:
The azimuth file contains in one degree intervals, both maximum distance (km) 
and lowest elevation. The file is updated by default every 10 minutes, 
but only if there have been changes.

I've not yet tried to adjust the interactive display for range and elevation, on 
this fork though I had that originally.  When the sky is clear it helps spot an 
approaching plane.

The javascript can pull in the azimuth plot multiple times so you can see e.g. if 
there have been changes in the last hour. (any pulled in plot may be deleted)

I like to see trails, so I can see at a glance if there's a plane doing
something interesting. e.g. been put in a stack where I expected it to just
land. Sometimes I'm away and I like to see where the planes have been,
hence all the trail display options.

When viewing, I find one update every 2 to 5 seconds is normally sufficient.
If I'm reading another tab, I don't see why the browser should waste it's and
the server's CPU time updating every second.  If the window loses visibility 
the updates reduce to 45 seconds.

In that time, of course, the planes can move quite a way.  Hence the server now
keeps a small (runtime-configurable) cache of old positions. The change to
the server code to make it remember e.g. altitude would be 1 changed #define
and 2 more lines.

This also means that if the browser has only just started then trails are still
available. To avoid wasted CPU cycles on browser & server,  the browser tries
to guess a sensible number of positions, rather than the whole cache.

Guesses: My kids get really confused by planes just sitting there while another
seemingly runs into it. If a plane hasn't moved in >5 seconds, the browser starts
calculating and displays an arrow showing where the plane probably is. 
I don't know if it's noise-related or just normal, but I frequently see a plane's heading 
being updated but no new positions for > 30 seconds, and I'm pleasantly surprised how 
accurately the guesses work out, even when the plane turns.
Maybe the guess's label should show the flight number, but so far it just gives the hexcode.
