### PR TITLE
Add a filter code for a range of ICAO 24-bit addresses

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -430,6 +430,15 @@ void modesSendSBSOutput(struct modesMessage *mm) {
 //=========================================================================
 //
 void modesQueueOutput(struct modesMessage *mm) {
+    // local mod: ITM filter mode
+    uint32_t addr;
+    
+    addr = mm->addr;
+    if ((addr >= 0x87a0d8) && (addr <= 0x87a0db)) {
+    	return;
+    }
+    // ITM filter mode ends
+
     if (Modes.stat_sbs_connections)   {modesSendSBSOutput(mm);}
     if (Modes.stat_beast_connections) {modesSendBeastOutput(mm);}
     if (Modes.stat_raw_connections)   {modesSendRawOutput(mm);}

--- a/net_io.c
+++ b/net_io.c
@@ -430,14 +430,25 @@ void modesSendSBSOutput(struct modesMessage *mm) {
 //=========================================================================
 //
 void modesQueueOutput(struct modesMessage *mm) {
+#ifdef ITM_FILTER
     // local mod: ITM filter mode
+    // This patch is to prevent external feeding of
+    // the stations in a range of ICAO 24-bit address;
+    // The range hardcoded below is for
+    // Osaka Int'l Airport (ITM/RJOO) and vicinity,
+    // where you can receive the regular transponder traffic
+    // of the ID range 0x87d0a8 to 0x87d0ab,
+    // which takes about 30% to 40% of all receiving frames.
     uint32_t addr;
-    
+
     addr = mm->addr;
+    // do nothing when ICAO 24-bit address are in the
+    // range between 0x87d0a8 to 0x87d0ab
     if ((addr >= 0x87a0d8) && (addr <= 0x87a0db)) {
-    	return;
+        return;
     }
     // ITM filter mode ends
+#endif // ITM_FILTER
 
     if (Modes.stat_sbs_connections)   {modesSendSBSOutput(mm);}
     if (Modes.stat_beast_connections) {modesSendBeastOutput(mm);}


### PR DESCRIPTION
This code is to reduce the non-informational regular traffic such as the periodic signals for the local transponders by filtering them with ICAO 24-bit addresses.  The filtered contents will not show up to the external feeds on TCP port 30001, 30002, and 30003, though they are visible on the port 8080 HTTP server. I find this filtering useful to reduce processing load for feeding from dump1090 to Flightradar24.

I've made it as an `#ifdef` clause so that this code will not change the default behavior.
