### PR TITLE
Incorrect value for auto-gain

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -394,7 +394,7 @@ void showHelp(void) {
 "|                        dump1090 ModeS Receiver         Ver : " MODES_DUMP1090_VERSION " |\n"
 "-----------------------------------------------------------------------------\n"
 "--device-index <index>   Select RTL device (default: 0)\n"
-"--gain <db>              Set gain (default: max gain. Use -100 for auto-gain)\n"
+"--gain <db>              Set gain (default: max gain. Use -10 for auto-gain)\n"
 "--enable-agc             Enable the Automatic Gain Control (default: off)\n"
 "--freq <hz>              Set frequency (default: 1090 Mhz)\n"
 "--ifile <filename>       Read data from file (use '-' for stdin)\n"


### PR DESCRIPTION
Incorrect value for auto-gain option the Modes.gain is multiplied by 10.
