### PR TITLE
make network services disable-able

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -415,7 +415,7 @@ void showHelp(void) {
 "--net-bo-port <port>     TCP Beast output listen port (default: 30005)\n"
 "--net-ro-size <size>     TCP raw output minimum size (default: 0)\n"
 "--net-ro-rate <rate>     TCP raw output memory flush rate (default: 0)\n"
-"--net-heartbeat <rate>   TCP heartbeat rate in seconds (default: 60 sec)\n"
+"--net-heartbeat <rate>   TCP heartbeat rate in seconds (default: 60 sec; 0 to disable)\n"
 "--net-buffer <n>         TCP buffer size 64Kb * (2^n) (default: n=0, 64Kb)\n"
 "--lat <latitude>         Reference/receiver latitude for surface posn (opt)\n"
 "--lon <longitude>        Reference/receiver longitude for surface posn (opt)\n"


### PR DESCRIPTION
This pull adds:
1. Documentation on the (possibly unintended? :-) ) ability to disable the TCP heartbeat, by providing `0` as the interval; this is useful when one does not have concerns about timing out, and does not want to go through filtering out heartbeats.
2. A similar method to disable some/all of the network services by providing `0` as the port number. This remains undocumented for now (I am not sure where to best document it). (Port `0` <a href="http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml">is a valid port</a>, but is used here , since (1) it would probably not be selected by users, and (2) numbers above 65535 might be handled incorrectly by code which assumes a 2-byte C integer)

Hopefully the code is clean and bug/exploit free; I am new to this kind of code, arrays of structs and all, so feel free to clean if needed.
