### PR TITLE
Change the Background Color for a Plotted Plane

### DIFF
--- a/public_html/style.css
+++ b/public_html/style.css
@@ -17,7 +17,7 @@ table#optionsTabs { width: 100%; font-size: small; font-family: monospace; backg
 #tableinfo { font-size: x-small; font-family: monospace; }
 #sudo_buttons { font-size: x-small; font-family: monospace; }
 
-.vPosition  { font-weight: bold; background-color: #f5fff5; }
+.vPosition  { font-weight: bold; background-color: #d5ffd5; }
 .squawk7500 { font-weight: bold; background-color: #ff5555; }
 .squawk7600 { font-weight: bold; background-color: #00ffff; }
 .squawk7700 { font-weight: bold; background-color: #ffff00; }


### PR DESCRIPTION
Changed the background color for a plotted plane in the planes table to
something that was more easily visible.
