### PR TITLE
Close network file descriptors when finished with them

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -161,8 +161,15 @@ void modesFreeClient(struct client *c) {
         }
     }
 
-    // It's now safe to remove this client
-    close(c->fd);
+    free(c);
+}
+//
+//=========================================================================
+//
+// Close the client connection and mark it as closed
+//
+void modesCloseClient(struct client *c) {
+	close(c->fd);
     if (c->service == Modes.sbsos) {
         if (Modes.stat_sbs_connections) Modes.stat_sbs_connections--;
     } else if (c->service == Modes.ros) {
@@ -174,7 +181,7 @@ void modesFreeClient(struct client *c) {
     if (Modes.debug & MODES_DEBUG_NET)
         printf("Closing client %d\n", c->fd);
 
-    free(c);
+    c->fd = -1;
 }
 //
 //=========================================================================
@@ -188,15 +195,19 @@ void modesSendAllClients(int service, void *msg, int len) {
         // Read next before servicing client incase the service routine deletes the client! 
         struct client *next = c->next;
 
-        if (c->service == service) {
+        if (c->fd != -1) {
+            if (c->service == service) {
 #ifndef _WIN32
-            int nwritten = write(c->fd, msg, len);
+                int nwritten = write(c->fd, msg, len);
 #else
-            int nwritten = send(c->fd, msg, len, 0 );
+                int nwritten = send(c->fd, msg, len, 0 );
 #endif
-            if (nwritten != len) {
-                modesFreeClient(c);
+                if (nwritten != len) {
+                    modesCloseClient(c);
+                }
             }
+        } else {
+            modesFreeClient(c);
         }
         c = next;
     }
@@ -707,11 +718,12 @@ int handleHTTPRequest(struct client *c, char *p) {
     httpver = (strstr(p, "HTTP/1.1") != NULL) ? 11 : 10;
     if (httpver == 10) {
         // HTTP 1.0 defaults to close, unless otherwise specified.
-        keepalive = strstr(p, "Connection: keep-alive") != NULL;
+        //keepalive = strstr(p, "Connection: keep-alive") != NULL;
     } else if (httpver == 11) {
         // HTTP 1.1 defaults to keep-alive, unless close is specified.
-        keepalive = strstr(p, "Connection: close") == NULL;
+        //keepalive = strstr(p, "Connection: close") == NULL;
     }
+    keepalive = 0;
 
     // Identify he URL.
     p = strchr(p,' ');
@@ -775,7 +787,7 @@ int handleHTTPRequest(struct client *c, char *p) {
 
     // Create the header and send the reply
     hdrlen = snprintf(hdr, sizeof(hdr),
-        "HTTP/1.1 200 OK\r\n"
+        "HTTP/1.0 200 OK\r\n"
         "Server: Dump1090\r\n"
         "Content-Type: %s\r\n"
         "Connection: %s\r\n"
@@ -845,6 +857,10 @@ void modesReadFromClient(struct client *c, char *sep,
         nread = recv(c->fd, c->buf+c->buflen, left, 0);
         if (nread < 0) {errno = WSAGetLastError();}
 #endif
+        if (nread == 0) {
+			modesCloseClient(c);
+			return;
+		}
 
         // If we didn't get all the data we asked for, then return once we've processed what we did get.
         if (nread != left) {
@@ -855,7 +871,7 @@ void modesReadFromClient(struct client *c, char *sep,
 #else
         if ( (nread < 0) && (errno != EWOULDBLOCK)) { // Error, or end of file
 #endif
-            modesFreeClient(c);
+            modesCloseClient(c);
         }
         if (nread <= 0) {
             break; // Serve next client
@@ -902,7 +918,7 @@ void modesReadFromClient(struct client *c, char *sep,
                 }
                 // Have a 0x1a followed by 1, 2 or 3 - pass message less 0x1a to handler.
                 if (handler(c, s)) {
-                    modesFreeClient(c);
+                    modesCloseClient(c);
                     return;
                 }
                 fullmsg = 1;
@@ -918,7 +934,7 @@ void modesReadFromClient(struct client *c, char *sep,
             while ((e = strstr(s, sep)) != NULL) { // end of first message if found
                 *e = '\0';                         // The handler expects null terminated strings
                 if (handler(c, s)) {               // Pass message to handler.
-                    modesFreeClient(c);            // Handler returns 1 on error to signal we .
+                    modesCloseClient(c);           // Handler returns 1 on error to signal we .
                     return;                        // should close the client connection
                 }
                 s = e + strlen(sep);               // Move to start of next message
@@ -945,15 +961,19 @@ void modesReadFromClients(void) {
     struct client *c = modesAcceptClients();
 
     while (c) {
-        // Read next before servicing client incase the service routine deletes the client! 
-        struct client *next = c->next;
+            // Read next before servicing client incase the service routine deletes the client! 
+            struct client *next = c->next;
 
-        if (c->service == Modes.ris) {
-            modesReadFromClient(c,"\n",decodeHexMessage);
-        } else if (c->service == Modes.bis) {
-            modesReadFromClient(c,"",decodeBinMessage);
-        } else if (c->service == Modes.https) {
-            modesReadFromClient(c,"\r\n\r\n",handleHTTPRequest);
+        if (c->fd >= 0) {
+            if (c->service == Modes.ris) {
+                modesReadFromClient(c,"\n",decodeHexMessage);
+            } else if (c->service == Modes.bis) {
+                modesReadFromClient(c,"",decodeBinMessage);
+            } else if (c->service == Modes.https) {
+                modesReadFromClient(c,"\r\n\r\n",handleHTTPRequest);
+            }
+        } else {
+            modesFreeClient(c);
         }
         c = next;
     }

--- a/net_io.c
+++ b/net_io.c
@@ -787,7 +787,7 @@ int handleHTTPRequest(struct client *c, char *p) {
 
     // Create the header and send the reply
     hdrlen = snprintf(hdr, sizeof(hdr),
-        "HTTP/1.0 200 OK\r\n"
+        "HTTP/1.1 200 OK\r\n"
         "Server: Dump1090\r\n"
         "Content-Type: %s\r\n"
         "Connection: %s\r\n"


### PR DESCRIPTION
These modifications help ensure that socket fds are closed when finished/closed.

This makes it so that the process's file descriptors will not be easily exhausted in normal course of use.

This affected HTTP connections which create a new conection every second for each browser-client; after a while no new network connections could be made to dump1090.

(`--debug n` really helps visualize what is happening here.)

(Although not mentioned in the commit messages, it also fixes a bug which would segfault when accessing closed, deallocated send-sockets (modesSendAllClients) which were not written to, and then opening a read-socket (modesReadFromClient); the socket would be automatically freed by modesFreeClient, and then modesReadFromClients would try accessing the freed client struct, segfaulting the program. This was corrected by adding the modesCloseClient function, which closes the client connection and marks it as invalid, and clients are only actually freed later).
