### PR TITLE
Check if bit correction happened before bailing out due to a bad CRC.

### DIFF
--- a/mode_s.c
+++ b/mode_s.c
@@ -909,7 +909,7 @@ void decodeModesMessage(struct modesMessage *mm, unsigned char *msg) {
 
     // If we're checking CRC and the CRC is invalid, then we can't trust any 
     // of the data contents, so save time and give up now.
-    if ((Modes.check_crc) && (!mm->crcok)) { return;}
+    if ((Modes.check_crc) && (!mm->crcok) && (!mm->correctedbits)) { return;}
 
     // Fields for DF0, DF16
     if (mm->msgtype == 0  || mm->msgtype == 16) {


### PR DESCRIPTION
decodeModesMessage would bail out early if the CRC was originally bad, even if --fix was in effect and one or two bits had been successfully repaired. Then much of the body of the message would not be decoded (e.g. all of the extended squitter).
