### PR TITLE
Prefer to use global CPR decoding where possible.

### DIFF
--- a/dump1090.h
+++ b/dump1090.h
@@ -433,7 +433,7 @@ void decodeModesMessage (struct modesMessage *mm, unsigned char *msg);
 void displayModesMessage(struct modesMessage *mm);
 void useModesMessage    (struct modesMessage *mm);
 void computeMagnitudeVector(uint16_t *pData);
-void decodeCPR          (struct aircraft *a, int fflag, int surface);
+int  decodeCPR          (struct aircraft *a, int fflag, int surface);
 int  decodeCPRrelative  (struct aircraft *a, int fflag, int surface);
 void modesInitErrorInfo ();
 //


### PR DESCRIPTION
There is a danger in always using relative decoding where possible.
If there is an undetected error in the first pair of messages received,
then global CPR decoding will give a bad position, and subsequent
relative decoding will just walk around near that bad position even
though many error-free pairs of odd/even messages may have been received.

The first pair of position messages also tends to be the most error-prone, as
they are usually received at the extreme edge of receiver range.

(I see this happen at least once a day in practice)

So, instead, prefer to use global decoding when we have sufficiently recent data.
With recent data this should always be as good as relative decoding, and it
avoids getting stuck with bad data for long periods of time. If we don't have
enough recent data for a global solution, fall back to relative decoding.
