### PR TITLE
Only use O_BINARY on Win32

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -710,7 +710,13 @@ int main(int argc, char **argv) {
     } else {
         if (Modes.filename[0] == '-' && Modes.filename[1] == '\0') {
             Modes.fd = STDIN_FILENO;
-        } else if ((Modes.fd = open(Modes.filename, (O_RDONLY | O_BINARY))) == -1) {
+        } else if ((Modes.fd = open(Modes.filename,
+#ifdef _WIN32
+                                    (O_RDONLY | O_BINARY)
+#else
+                                    (O_RDONLY)
+#endif
+                                    )) == -1) {
             perror("Opening data file");
             exit(1);
         }


### PR DESCRIPTION
Use of O_BINARY fails on Linux systems:

```
gcc -O2 -g -Wall -W `pkg-config --cflags librtlsdr`  -c dump1090.c
dump1090.c: In function ‘main’:
dump1090.c:713:65: error: ‘O_BINARY’ undeclared (first use in this function)
         } else if ((Modes.fd = open(Modes.filename, (O_RDONLY | O_BINARY))) == -1) {
                                                                 ^
```
