### PR TITLE
Detect client EOF properly. Handle EWOULDBLOCK.

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -851,11 +851,12 @@ void modesReadFromClient(struct client *c, char *sep,
             bContinue = 0;
         }
 #ifndef _WIN32
-        if ( (nread < 0) && (errno != EAGAIN)) { // Error, or end of file
+        if ( (nread < 0 && errno != EAGAIN && errno != EWOULDBLOCK) || nread == 0 ) { // Error, or end of file
 #else
         if ( (nread < 0) && (errno != EWOULDBLOCK)) { // Error, or end of file
 #endif
             modesFreeClient(c);
+            return;
         }
         if (nread <= 0) {
             break; // Serve next client


### PR DESCRIPTION
Client disconnection appears as a read of 0 bytes.
Without a test for this, dump1090 continues to poll that client forever.

Also, read() may return EWOULDBLOCK as well as EAGAIN
for "no data right now", so handle that.

I don't know if there is an equivalent Win32 bug here as the Win32
interfaces seem subtly different to vanilla POSIX.

The following test/break can probably be removed if Win32 needs
the same fix.
