### PR TITLE
Fix a crash when an outbound client is closed in response to reading a remote message

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -490,6 +490,7 @@ void showCopyright(void) {
 void backgroundTasks(void) {
     if (Modes.net) {
         modesReadFromClients();
+        modesNetCleanup();
     }    
 
     // If Modes.aircrafts is not NULL, remove any stale aircraft

--- a/dump1090.h
+++ b/dump1090.h
@@ -454,6 +454,7 @@ void modesReadFromClients (void);
 void modesSendAllClients  (int service, void *msg, int len);
 void modesQueueOutput     (struct modesMessage *mm);
 void modesReadFromClient(struct client *c, char *sep, int(*handler)(struct client *, char *));
+void modesNetCleanup      (void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When we read from some client A, we may end up forwarding a message to other
clients. If we forward to some client B and there is a write error, then
we close B and remove it from the client list. However, if before this happened
A->next == B, then the read loop will still be holding on to a pointer to B,
and we crash.

As it's unpredictable what clients could be closed at what point, the simplest
approach is to retain closed clients in the list until we are at a point where
we know there are no stray pointers on stack, and only then modify the list.
This also simplifies anything that has to loop over clients, as it doesn't need
to worry about the current client being freed under it.
