### PR TITLE
Avoid javascript memory leaks on web page

### DIFF
--- a/public_html/gmap.html
+++ b/public_html/gmap.html
@@ -49,7 +49,22 @@
 
 				<div id="plane_detail"></div>
 				<div id="options"></div>
-				<div id="planes_table"></div>
+				<div id="planes_table">
+					<table id="tableinfo" width="100%">
+						<thead style="background-color: #BBBBBB; cursor: pointer;">
+							<td onclick="setASC_DESC('0');sortTable('tableinfo','0');">ICAO</td>
+							<td onclick="setASC_DESC('1');sortTable('tableinfo','1');">Flight</td>
+							<td onclick="setASC_DESC('2');sortTable('tableinfo','2');" align="right">Squawk</td>
+							<td onclick="setASC_DESC('3');sortTable('tableinfo','3');" align="right">Altitude</td>
+							<td onclick="setASC_DESC('4');sortTable('tableinfo','4');" align="right">Speed</td>
+							<td onclick="setASC_DESC('5');sortTable('tableinfo','5');" align="right">Track</td>
+							<td onclick="setASC_DESC('6');sortTable('tableinfo','6');" align="right">Msgs</td>
+							<td onclick="setASC_DESC('7');sortTable('tableinfo','7');" align="right">Seen</td>
+						</thead>
+						<tbody id="dataTable">
+						</tbody>
+					</table>
+				</div>
 				<div id="plane_extension"></div>
 			</div>
 		</div>

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -393,22 +393,7 @@ function normalizeTrack(track, valid){
 
 // Refeshes the larger table of all the planes
 function refreshTableInfo() {
-	var html = '<table id="tableinfo" width="100%">';
-	html += '<thead style="background-color: #BBBBBB; cursor: pointer;">';
-	html += '<td onclick="setASC_DESC(\'0\');sortTable(\'tableinfo\',\'0\');">ICAO</td>';
-	html += '<td onclick="setASC_DESC(\'1\');sortTable(\'tableinfo\',\'1\');">Flight</td>';
-	html += '<td onclick="setASC_DESC(\'2\');sortTable(\'tableinfo\',\'2\');" ' +
-	    'align="right">Squawk</td>';
-	html += '<td onclick="setASC_DESC(\'3\');sortTable(\'tableinfo\',\'3\');" ' +
-	    'align="right">Altitude</td>';
-	html += '<td onclick="setASC_DESC(\'4\');sortTable(\'tableinfo\',\'4\');" ' +
-	    'align="right">Speed</td>';
-	html += '<td onclick="setASC_DESC(\'5\');sortTable(\'tableinfo\',\'5\');" ' +
-	    'align="right">Track</td>';
-	html += '<td onclick="setASC_DESC(\'6\');sortTable(\'tableinfo\',\'6\');" ' +
-	    'align="right">Msgs</td>';
-	html += '<td onclick="setASC_DESC(\'7\');sortTable(\'tableinfo\',\'7\');" ' +
-	    'align="right">Seen</td></thead><tbody>';
+	var html = '';
 	for (var tablep in Planes) {
 		var tableplane = Planes[tablep]
 		if (!tableplane.reapable) {
@@ -431,9 +416,9 @@ function refreshTableInfo() {
 			}
 			
 			if (tableplane.vPosition == true) {
-				html += '<tr class="plane_table_row vPosition' + specialStyle + '">';
+				html += '<tr onclick="planeTRclick(\''+tableplane.icao+'\')" class="plane_table_row vPosition' + specialStyle + '">';
 			} else {
-				html += '<tr class="plane_table_row ' + specialStyle + '">';
+				html += '<tr onclick="planeTRclick(\''+tableplane.icao+'\')" class="plane_table_row ' + specialStyle + '">';
 		    }
 		    
 			html += '<td>' + tableplane.icao + '</td>';
@@ -465,25 +450,14 @@ function refreshTableInfo() {
 			html += '</tr>';
 		}
 	}
-	html += '</tbody></table>';
 
-	document.getElementById('planes_table').innerHTML = html;
+	document.getElementById('dataTable').innerHTML = html;
 
 	if (SpecialSquawk) {
     	$('#SpecialSquawkWarning').css('display', 'inline');
     } else {
         $('#SpecialSquawkWarning').css('display', 'none');
     }
-
-	// Click event for table
-	$('#planes_table').find('tr').click( function(){
-		var hex = $(this).find('td:first').text();
-		if (hex != "ICAO") {
-			selectPlaneByHex(hex);
-			refreshTableInfo();
-			refreshSelected();
-		}
-	});
 
 	sortTable("tableinfo");
 }
@@ -627,4 +601,10 @@ function drawCircle(marker, distance) {
       strokeOpacity: 0.3
     });
     circle.bindTo('center', marker, 'position');
+}
+
+function planeTRclick(hex) {
+	selectPlaneByHex(hex);
+	refreshTableInfo();
+	refreshSelected();
 }


### PR DESCRIPTION
When leaving a web browser open for an extended period of time, the memory usage of the browser will continue to increase as table rows for each new aircraft is added or removed.

The largest part of this leak appears to be caused by adding a new click event handler for each row, so this was changed to use a more conventional onclick handler with a javascript function that is defined globally once.
