### PR TITLE
DF 18 / Control field 5 cluttering interactive display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 CFLAGS=-O2 -g -Wall -W `pkg-config --cflags librtlsdr`
 LIBS=`pkg-config --libs librtlsdr` -lpthread -lm
-CC=gcc
 PROGNAME=dump1090
 
 all: dump1090

--- a/TODO
+++ b/TODO
@@ -3,3 +3,4 @@ TODO
 * Extract more information from captured Mode S messages.
 * Improve the web interface gmap.html.
 * Enhance the algorithm to reliably decode more messages.
+* Handle DF-18 control field 5 / TIS-B 

--- a/dump1090.c
+++ b/dump1090.c
@@ -1078,7 +1078,7 @@ void decodeModesMessage(struct modesMessage *mm, unsigned char *msg) {
                 mm->ns_dir = (msg[7]&0x80) >> 7;
                 mm->ns_velocity = ((msg[7]&0x7f) << 3) | ((msg[8]&0xe0) >> 5);
                 mm->vert_rate_source = (msg[8]&0x10) >> 4;
-                mm->vert_rate_sign = (msg[8]&0x8) >> 5;
+                mm->vert_rate_sign = (msg[8]&0x8) >> 3;
                 mm->vert_rate = ((msg[8]&7) << 6) | ((msg[9]&0xfc) >> 2);
                 /* Compute velocity and angle from the two speed
                  * components. */

--- a/dump1090.c
+++ b/dump1090.c
@@ -1610,6 +1610,7 @@ int cprModFunction(int a, int b) {
 
 /* The NL function uses the precomputed table from 1090-WP-9-14 */
 int cprNLFunction(double lat) {
+    if (lat < 0) lat = -lat; /* Table is simmetric about the equator. */
     if (lat < 10.47047130) return 59;
     if (lat < 14.82817437) return 58;
     if (lat < 18.18626357) return 57;

--- a/dump1090.c
+++ b/dump1090.c
@@ -2359,7 +2359,7 @@ void showHelp(void) {
     printf(
 "--device-index <index>   Select RTL device (default: 0).\n"
 "--gain <db>              Set gain (default: max gain. Use -100 for auto-gain).\n"
-"--enable-agc>            Enable the Automatic Gain Control (default: off).\n"
+"--enable-agc             Enable the Automatic Gain Control (default: off).\n"
 "--freq <hz>              Set frequency (default: 1090 Mhz).\n"
 "--ifile <filename>       Read data from file (use '-' for stdin).\n"
 "--interactive            Interactive mode refreshing data on screen.\n"


### PR DESCRIPTION
(This is a dummy commit/PR.  Sorry, I would open an issue but the repo doesn't have issues.  Let me know if there's a better place to talk about this sort of thing.)

In Los Angeles I'm currently getting a lot of messages like this:

```
*95c60bf13b4db286b30fc180d20d;
CRC: 000000 (ok)
DF 18: Extended Squitter.
  Control Field : 5 (TIS-B relay of ADS-B message with other address)
```

I also see a lot of what look like dozens of bogus entries in the interactive display:

```
C6021C  S                                                        50     3   21
C60979  S                                                        53    10   18
C6067B  S                                                        49    22    2
C601EB  S                                                        49    18    5
C60A6C  S                                                        53    12   17
C60795  S                                                        41     4   18
C601DA  S                                                        52    17    1
C60C20  S                                                        46    10   19
C6092E  S                                                        47    24    1
C609B1  S                                                        47     9   19
C60B19  S                                                        44    28    1
C60FC6  S                                                        49    13   17
C6078C  S                                                        51    11   18
C601B7  S                                                        48    12   18
C60250  S                                                        44    21    2
C60130  S                                                        49    27    1
C60BF5  S                                                        51     3   23
C60652  S                                                        50     6   18
...
```

I don't know the details of DF 18, but the code that prints DF 18 doesn't seem to think there's an address in the message, due to the `mm->ca` guards here:

```
        if ((mm->ca == 0) || (mm->ca == 1) || (mm->ca == 6)) {
            if (mm->ca == 1) {
                printf("  Other Address : %06x\n", mm->addr);
            } else {
                printf("  ICAO Address  : %06x\n", mm->addr);
            }
```

But maybe the interactive display (and web API) is somewhat blindly showing the entries with the address, which is invalid?
