### PR TITLE
Ability to assign bind address for services

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -76,6 +76,7 @@ void modesInitConfig(void) {
     Modes.net_input_raw_port      = MODES_NET_INPUT_RAW_PORT;
     Modes.net_output_beast_port   = MODES_NET_OUTPUT_BEAST_PORT;
     Modes.net_input_beast_port    = MODES_NET_INPUT_BEAST_PORT;
+    Modes.net_bind_address        = MODES_NET_BIND_ADDRESS;
     Modes.net_http_port           = MODES_NET_HTTP_PORT;
     Modes.interactive_rows        = getTermRows();
     Modes.interactive_delete_ttl  = MODES_INTERACTIVE_DELETE_TTL;
@@ -409,6 +410,7 @@ void showHelp(void) {
 "--modeac                 Enable decoding of SSR Modes 3/A & 3/C\n"
 "--net-beast              TCP raw output in Beast binary format\n"
 "--net-only               Enable just networking, no RTL device or file used\n"
+"--net-bind-address <ip>  IP address to bind to (default: 127.0.0.1; 0.0.0.0 for public)\n"
 "--net-http-port <port>   HTTP server port (default: 8080)\n"
 "--net-ri-port <port>     TCP raw input listen port  (default: 30001)\n"
 "--net-ro-port <port>     TCP raw output listen port (default: 30002)\n"
@@ -716,6 +718,8 @@ int main(int argc, char **argv) {
             Modes.net_output_beast_port = atoi(argv[++j]);
         } else if (!strcmp(argv[j],"--net-bi-port") && more) {
             Modes.net_input_beast_port = atoi(argv[++j]);
+        } else if (!strcmp(argv[j],"--net-bind-address") && more) {
+            Modes.net_bind_address = argv[++j];
         } else if (!strcmp(argv[j],"--net-http-port") && more) {
             Modes.net_http_port = atoi(argv[++j]);
         } else if (!strcmp(argv[j],"--net-sbs-port") && more) {

--- a/dump1090.h
+++ b/dump1090.h
@@ -173,6 +173,7 @@
 #define MODES_NET_OUTPUT_SBS_PORT   30003
 #define MODES_NET_INPUT_BEAST_PORT  30004
 #define MODES_NET_OUTPUT_BEAST_PORT 30005
+#define MODES_NET_BIND_ADDRESS      "127.0.0.1"
 #define MODES_NET_HTTP_PORT          8080
 #define MODES_CLIENT_BUF_SIZE  1024
 #define MODES_NET_SNDBUF_SIZE (1024*64)
@@ -305,6 +306,7 @@ struct {                             // Internal state
     int   net_input_raw_port;        // Raw input TCP port
     int   net_output_beast_port;     // Beast output TCP port
     int   net_input_beast_port;      // Beast input TCP port
+    char  *net_bind_address;         // Bind address
     int   net_http_port;             // HTTP port
     int   net_sndbuf_size;           // TCP output buffer size (64Kb * 2^n)
     int   quiet;                     // Suppress stdout

--- a/net_io.c
+++ b/net_io.c
@@ -85,7 +85,7 @@ void modesInitNet(void) {
     for (j = 0; j < MODES_NET_SERVICES_NUM; j++) {
 		services[j].enabled = (services[j].port != 0);
 		if (services[j].enabled) {
-			int s = anetTcpServer(Modes.aneterr, services[j].port, NULL);
+			int s = anetTcpServer(Modes.aneterr, services[j].port, Modes.net_bind_address);
 			if (s == -1) {
 				fprintf(stderr, "Error opening the listening port %d (%s): %s\n",
 					services[j].port, services[j].descr, Modes.aneterr);


### PR DESCRIPTION
Ability to change what address dump1090 services bind to. Default set to localhost (to stop any unauthorized access to the web interface from the local network by default).
