### PR TITLE
Makefile tweaks to make packaging easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SHAREDIR=$(PREFIX)/share/$(PROGNAME)
 EXTRACFLAGS=-DHTMLPATH=\"$(SHAREDIR)\"
 endif
 
-CFLAGS=-O2 -g -Wall -W `pkg-config --cflags librtlsdr`
+CFLAGS+=-O2 -g -Wall -W `pkg-config --cflags librtlsdr`
 LIBS=`pkg-config --libs librtlsdr` -lpthread -lm
 CC=gcc
 
@@ -18,7 +18,7 @@ CC=gcc
 all: dump1090 view1090
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(EXTRACFLAGS) -c $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(EXTRACFLAGS) -c $<
 
 dump1090: dump1090.o anet.o interactive.o mode_ac.o mode_s.o net_io.o
 	$(CC) -g -o dump1090 dump1090.o anet.o interactive.o mode_ac.o mode_s.o net_io.o $(LIBS) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ EXTRACFLAGS=-DHTMLPATH=\"$(SHAREDIR)\"
 endif
 
 CFLAGS+=-O2 -g -Wall -W `pkg-config --cflags librtlsdr`
-LIBS=`pkg-config --libs librtlsdr` -lpthread -lm
+LIBS=-lpthread -lm
+LIBS_RTL=`pkg-config --libs librtlsdr`
 CC=gcc
 
 
@@ -21,7 +22,7 @@ all: dump1090 view1090
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(EXTRACFLAGS) -c $<
 
 dump1090: dump1090.o anet.o interactive.o mode_ac.o mode_s.o net_io.o
-	$(CC) -g -o dump1090 dump1090.o anet.o interactive.o mode_ac.o mode_s.o net_io.o $(LIBS) $(LDFLAGS)
+	$(CC) -g -o dump1090 dump1090.o anet.o interactive.o mode_ac.o mode_s.o net_io.o $(LIBS) $(LIBS_RTL) $(LDFLAGS)
 
 view1090: view1090.o anet.o interactive.o mode_ac.o mode_s.o net_io.o
 	$(CC) -g -o view1090 view1090.o anet.o interactive.o mode_ac.o mode_s.o net_io.o $(LIBS) $(LDFLAGS)


### PR DESCRIPTION
Two changes to support Debian's hardening mechanism, which would like to provide extra CFLAGS/CPPFLAGS when building:
- Add to CFLAGS, rather than overriding its value
- Include CPPFLAGS (preprocessor flags) when compiling

And one change to remove an unnecessary library dependency:
- Don't link view1090 to librtlsdr, it doesn't use it.
