### PR TITLE
Fix a memory leak from use of realpath() in HTTP request processing.

### DIFF
--- a/dump1090.h
+++ b/dump1090.h
@@ -57,6 +57,7 @@
     #include <ctype.h>
     #include <sys/stat.h>
     #include <sys/ioctl.h>
+    #include <limits.h>
     #include "rtl-sdr.h"
     #include "anet.h"
 #else

--- a/net_io.c
+++ b/net_io.c
@@ -762,14 +762,16 @@ int handleHTTPRequest(struct client *c, char *p) {
     } else {
         struct stat sbuf;
         int fd = -1;
-        char *rp, *hrp;
+        char rp[PATH_MAX], hrp[PATH_MAX];
 
-        rp = realpath(getFile, NULL);
-        hrp = realpath(HTMLPATH, NULL);
-        hrp = (hrp ? hrp : HTMLPATH);
+        if (!realpath(getFile, rp))
+            rp[0] = 0;
+        if (!realpath(HTMLPATH, hrp))
+            strcpy(hrp, HTMLPATH);
+
         clen = -1;
         content = strdup("Server error occured");
-        if (rp && (!strncmp(hrp, rp, strlen(hrp)))) {
+        if (!strncmp(hrp, rp, strlen(hrp))) {
             if (stat(getFile, &sbuf) != -1 && (fd = open(getFile, O_RDONLY)) != -1) {
                 content = (char *) realloc(content, sbuf.st_size);
                 if (read(fd, content, sbuf.st_size) != -1) {


### PR DESCRIPTION
realpath() returns a heap-allocated buffer if given NULL for the destination buffer.
This must be freed by the caller; dump1090 does not do this.

Instead of worrying about freeing it, take the simpler approach of just providing a
stack-allocated destination buffer.
