### PR TITLE
Use O_BINARY on Win32 when opening static files to serve via HTTP.

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -770,7 +770,11 @@ int handleHTTPRequest(struct client *c, char *p) {
         clen = -1;
         content = strdup("Server error occured");
         if (rp && (!strncmp(hrp, rp, strlen(hrp)))) {
-            if (stat(getFile, &sbuf) != -1 && (fd = open(getFile, O_RDONLY)) != -1) {
+            if (stat(getFile, &sbuf) != -1 && (fd = open(getFile, O_RDONLY
+#ifdef _WIN32
+                           | O_BINARY
+#endif
+                           )) != -1) {
                 content = (char *) realloc(content, sbuf.st_size);
                 if (read(fd, content, sbuf.st_size) != -1) {
                     clen = sbuf.st_size;


### PR DESCRIPTION
Otherwise the size reported by stat() may not match the number of bytes available to read(), as CRLF -> LF conversion happens.

See http://forum.flightradar24.com/threads/8358-DUMP1090-on-Windows-no-map-display-in-browser for the original report.

Untested! I have no Windows build environment.
