### PR TITLE
Fix off-by-one error in Beast-format input.

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -912,7 +912,7 @@ void modesReadFromClient(struct client *c, char *sep,
             // in the buffer, note that we full-scan the buffer at every read for simplicity.
 
             left = c->buflen;                                  // Length of valid search for memchr()
-            while (left && ((s = memchr(e, (char) 0x1a, left)) != NULL)) { // The first byte of buffer 'should' be 0x1a
+            while (left > 1 && ((s = memchr(e, (char) 0x1a, left)) != NULL)) { // The first byte of buffer 'should' be 0x1a
                 s++;                                           // skip the 0x1a
                 if        (*s == '1') {
                     e = s + MODEAC_MSG_BYTES      + 8;         // point past remainder of message


### PR DESCRIPTION
This would mangle messages if the first byte of a message ended up
as the last byte returned by a read() call - it would read beyond
the end of the buffer, decide the message was damaged, and then run
off into the message data looking for a new delimiter. Sometimes
that would work (only dropping one message), but sometimes it would
run into data that happened to look like a message start but
actually wasn't, and then try to interpret that, leading to completely
bogus message data being read.

(cherry picked from commit e7d7fd549ceede7350bd2c72b61265173d1f0d2d)
