### PR TITLE
Fix segfault in HTTP handler.

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -796,7 +796,7 @@ int handleHTTPRequest(struct client *c, char *p) {
     snprintf(ctype, sizeof ctype, MODES_CONTENT_TYPE_HTML); // Default content type
     ext = strrchr(getFile, '.');
 
-    if (strlen(ext) > 0) {
+    if (ext) {
         if (strstr(ext, ".json")) {
             snprintf(ctype, sizeof ctype, MODES_CONTENT_TYPE_JSON);
         } else if (strstr(ext, ".css")) {


### PR DESCRIPTION
dump1090 crashes when a non-existent file with no dot in its name is requested.
strrchr() will return NULL, not an empty string, when there is no match.
