### PR TITLE
Big endian timestamp fixes

### DIFF
--- a/mode_s.c
+++ b/mode_s.c
@@ -29,6 +29,10 @@
 //
 
 #include "dump1090.h"
+
+/* for PRIX64 */
+#include <inttypes.h>
+
 //
 // ===================== Mode S detection and decoding  ===================
 //
@@ -1144,7 +1148,6 @@ void decodeModesMessage(struct modesMessage *mm, unsigned char *msg) {
 //
 void displayModesMessage(struct modesMessage *mm) {
     int j;
-    unsigned char * pTimeStamp;
 
     // Handle only addresses mode first.
     if (Modes.onlyaddr) {
@@ -1154,11 +1157,7 @@ void displayModesMessage(struct modesMessage *mm) {
 
     // Show the raw message.
     if (Modes.mlat && mm->timestampMsg) {
-        printf("@");
-        pTimeStamp = (unsigned char *) &mm->timestampMsg;
-        for (j=5; j>=0;j--) {
-            printf("%02X",pTimeStamp[j]);
-        } 
+        printf("@%012" PRIX64, mm->timestampMsg);
     } else
         printf("*");
 

--- a/net_io.c
+++ b/net_io.c
@@ -282,6 +282,7 @@ void modesSendRawOutput(struct modesMessage *mm) {
         /* timestamp, big-endian */
         sprintf(p, "@%012" PRIx64,
                 mm->timestampMsg);
+        p += 13;
         Modes.rawOutUsed += 12; // additional 12 characters for timestamp
     } else
         *p++ = '*';

--- a/net_io.c
+++ b/net_io.c
@@ -30,7 +30,7 @@
 
 #include "dump1090.h"
 
-/* for PRIx64 */
+/* for PRIX64 */
 #include <inttypes.h>
 
 //
@@ -280,7 +280,7 @@ void modesSendRawOutput(struct modesMessage *mm) {
 
     if (Modes.mlat && mm->timestampMsg) {
         /* timestamp, big-endian */
-        sprintf(p, "@%012" PRIx64,
+        sprintf(p, "@%012" PRIX64,
                 mm->timestampMsg);
         p += 13;
         Modes.rawOutUsed += 12; // additional 12 characters for timestamp


### PR DESCRIPTION
Beast I/O, and AVR output in --mlat mode, assumed the host was little-endian.
This fixes them to work on both big- and little-endian hosts.
