### PR TITLE
Squawk codes are four-digit octal numbers

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -411,7 +411,7 @@ void modesSendSBSOutput(struct modesMessage *mm) {
     else                                           {p += sprintf(p, ",");}
 
     // Field 18 is  the Squawk (if we have it)
-    if (mm->bFlags & MODES_ACFLAGS_SQUAWK_VALID) {p += sprintf(p, ",%x", mm->modeA);}
+    if (mm->bFlags & MODES_ACFLAGS_SQUAWK_VALID) {p += sprintf(p, ",%04x", mm->modeA);}
     else                                         {p += sprintf(p, ",");}
 
     // Field 19 is the Squawk Changing Alert flag (if we have it)


### PR DESCRIPTION
According to Wikipedia (¹) '“[s]quawk codes are four-digit octal numbers”.  Earlier in the processing care has been taken to mask the squawk value with 0x7777, so I feel the proper thing to do here would be to use “,%04x” as formatting string rather than “,%x”, thus displaying all four octal numbers.

¹) https://en.wikipedia.org/wiki/Transponder_(aeronautics)#Transponder_codes
