### PR TITLE
Make it possible to compile dump1090 without librtlsdr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,19 @@ SHAREDIR=$(PREFIX)/share/$(PROGNAME)
 EXTRACFLAGS=-DHTMLPATH=\"$(SHAREDIR)\"
 endif
 
-CFLAGS=-O2 -g -Wall -W `pkg-config --cflags librtlsdr`
-LIBS=`pkg-config --libs librtlsdr` -lpthread -lm
+# Set NORTLSDR to compile without librtlsdr e.g. "make NORTLSDR=1"
+ifndef NORTLSDR
+ifeq ($(shell pkg-config --exists librtlsdr || echo "F"), F)
+$(warning librtlsdr not found - please install it, or build with "NORTLSDR=1" to build with RTL SDR support.)
+endif
+RTLSDR_CFLAGS=$(shell pkg-config --cflags librtlsdr)
+RTLSDR_LDFLAGS=$(shell pkg-config --libs librtlsdr)
+else
+RTLSDR_CFLAGS=-DNORTLSDR
+endif
+
+CFLAGS=-O2 -g -Wall -W $(RTLSDR_CFLAGS)
+LDFLAGS+=$(RTLSDR_LDFLAGS) -lpthread -lm
 CC=gcc
 
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Installation
 
 Type "make".
 
+To compile without RTL SDR support (your binaries will only be useable for
+network operations), run "make NORTLSDR=1" instead.
+
 Normal usage
 ---
 

--- a/dump1090.h
+++ b/dump1090.h
@@ -57,7 +57,10 @@
     #include <ctype.h>
     #include <sys/stat.h>
     #include <sys/ioctl.h>
+    #include <assert.h>
+#ifndef NORTLSDR
     #include "rtl-sdr.h"
+#endif
     #include "anet.h"
 #else
     #include "winstubs.h" //Put everything Windows specific in here
@@ -263,7 +266,9 @@ struct {                             // Internal state
     int           dev_index;
     int           gain;
     int           enable_agc;
+#ifndef NORTLSDR
     rtlsdr_dev_t *dev;
+#endif
     int           freq;
     int           ppm_error;
 

--- a/view1090.h
+++ b/view1090.h
@@ -51,10 +51,6 @@
     #include <sys/stat.h>
     #include <sys/types.h>
     #include <sys/socket.h>
-    #include <assert.h>
-#ifndef NORTLSDR
-    #include "rtl-sdr.h"
-#endif
     #include "anet.h"
 #else
     #include "winstubs.h" //Put everything Windows specific in here

--- a/view1090.h
+++ b/view1090.h
@@ -51,7 +51,10 @@
     #include <sys/stat.h>
     #include <sys/types.h>
     #include <sys/socket.h>
+    #include <assert.h>
+#ifndef NORTLSDR
     #include "rtl-sdr.h"
+#endif
     #include "anet.h"
 #else
     #include "winstubs.h" //Put everything Windows specific in here


### PR DESCRIPTION
I needed to compile dump1090 to run as a "network hub" on a box where I don't have admin access, so I couldn't install librtlsdr. Solution: Add a Makefile option to disable all calls to rtlsdr. Cons: Adds #ifdefs to code, some may not like that.

Not tested very well yet. (It compiles and runs with and without this options, but haven't tested it with any data yet.)
