### PR TITLE
realpath memory leak

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -781,6 +781,12 @@ int handleHTTPRequest(struct client *c, char *p) {
             errno = ENOENT;
         }
 
+        if (rp)
+            free(rp);
+
+        if (hrp)
+            free(hrp);
+
         if (clen < 0) {
             content = realloc(content, 128);
             clen = snprintf(content, 128,"Error opening HTML file: %s", strerror(errno));


### PR DESCRIPTION
hey- patched a small memory leak

```
before:
==400== LEAK SUMMARY:
==400==    definitely lost: 32,768 bytes in 8 blocks
==400==    indirectly lost: 0 bytes in 0 blocks
==400==      possibly lost: 0 bytes in 0 blocks
==400==    still reachable: 667,216 bytes in 7 blocks
==400==         suppressed: 0 bytes in 0 blocks
after:
==492==    definitely lost: 0 bytes in 0 blocks
==492==    indirectly lost: 0 bytes in 0 blocks
==492==      possibly lost: 0 bytes in 0 blocks
==492==    still reachable: 667,216 bytes in 7 blocks
==492==         suppressed: 0 bytes in 0 blocks
```
