### PR TITLE
dump1090.h: fix build with gcc 10

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -29,6 +29,9 @@
 //
 #include "coaa.h"
 #include "dump1090.h"
+
+struct modes Modes;
+
 //
 // ============================= Utility functions ==========================
 //

--- a/dump1090.h
+++ b/dump1090.h
@@ -235,10 +235,10 @@ struct stDF {
     uint64_t         llTimestamp;                // Timestamp at which the this packet was received
     uint32_t         addr;                       // Timestamp at which the this packet was received
     unsigned char    msg[MODES_LONG_MSG_BYTES];  // the binary
-} tDF;
+};
 
 // Program global state
-struct {                             // Internal state
+extern struct modes {                             // Internal state
     pthread_t       reader_thread;
 
     pthread_mutex_t data_mutex;      // Mutex to synchronize buffer access

--- a/view1090.c
+++ b/view1090.c
@@ -29,6 +29,9 @@
 //
 #include "coaa.h"
 #include "view1090.h"
+
+struct modes Modes;
+
 //
 // ============================= Utility functions ==========================
 //


### PR DESCRIPTION
Fix the following build failures on gcc 10 (where -fno-common is enabled by default):

```
/home/test/autobuild/run/instance-0/output-1/per-package/dump1090/host/bin/../lib/gcc/arm-buildroot-linux-gnueabihf/10.2.0/../../../../arm-buildroot-linux-gnueabihf/bin/ld: interactive.o:/home/test/autobuild/run/instance-0/output-1/build/dump1090-bff92c4ad772a0a8d433f788d39dae97e00e4dbe/dump1090.h:373: multiple definition of `Modes'; /home/test/autobuild/run/instance-0/output-1/per-package/dump1090/host/bin/../lib/gcc/arm-buildroot-linux-gnueabihf/10.2.0/../../../../arm-buildroot-linux-gnueabihf/bin/ld: interactive.o:/home/test/autobuild/run/instance-0/output-1/build/dump1090-bff92c4ad772a0a8d433f788d39dae97e00e4dbe/dump1090.h:373: multiple definition of `Modes'; dump1090.o:/home/test/autobuild/run/instance-0/output-1/build/dump1090-bff92c4ad772a0a8d433f788d39dae97e00e4dbe/dump1090.h:373: first defined here

/home/test/autobuild/run/instance-0/output-1/per-package/dump1090/host/bin/../lib/gcc/arm-buildroot-linux-gnueabihf/10.2.0/../../../../arm-buildroot-linux-gnueabihf/bin/ld: interactive.o:/home/test/autobuild/run/instance-0/output-1/build/dump1090-bff92c4ad772a0a8d433f788d39dae97e00e4dbe/dump1090.h:238: multiple definition of `tDF'; dump1090.o:/home/test/autobuild/run/instance-0/output-1/build/dump1090-bff92c4ad772a0a8d433f788d39dae97e00e4dbe/dump1090.h:238: first defined here
/home/test/autobuild/run/instance-0/output-1/per-package/dump1090/host/bin/../lib/gcc/arm-buildroot-linux-gnueabihf/10.2.0/../../../../arm-buildroot-linux-gnueabihf/bin/ld: view1090.o:/home/test/autobuild/run/instance-0/output-1/build/dump1090-bff92c4ad772a0a8d433f788d39dae97e00e4dbe/dump1090.h:373: first defined here

```
Fixes:
 - http://autobuild.buildroot.org/results/88dc97fcaa649014edb3b54a5dd4bd8ec4715bbd

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>