### PR TITLE
Correction to detectOutofPhase function in mode_s.c

### DIFF
--- a/mode_s.c
+++ b/mode_s.c
@@ -1453,7 +1453,7 @@ int detectOutOfPhase(uint16_t *pPreamble) {
     if (pPreamble[ 3] > pPreamble[2]/3) return  1;
     if (pPreamble[10] > pPreamble[9]/3) return  1;
     if (pPreamble[ 6] > pPreamble[7]/3) return -1;
-    if (pPreamble[-1] > pPreamble[1]/3) return -1;
+    if (pPreamble[-1] > pPreamble[0]/3) return -1;
     return 0;
 }
 


### PR DESCRIPTION
In mode_s.c, the detectOutofPhase function was comparing preamble bit -1 to bit 1, where it should have been comparing bit -1 to bit 0.